### PR TITLE
Make Path immutable

### DIFF
--- a/willow-data-model/src/data_model/path.rs
+++ b/willow-data-model/src/data_model/path.rs
@@ -105,7 +105,7 @@ impl<const MCL: usize> AsRef<[u8]> for PathComponentLocal<MCL> {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct PathLocal<const MCL: usize, const MCC: usize, const MPL: usize>(
-    Rc<Vec<PathComponentLocal<MCL>>>,
+    Rc<[PathComponentLocal<MCL>]>,
 );
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize> Path for PathLocal<MCL, MCC, MPL> {
@@ -133,11 +133,11 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> Path for PathLocal<MC
             }
         }
 
-        Ok(PathLocal(Rc::new(path_vec)))
+        Ok(PathLocal(path_vec.into()))
     }
 
     fn empty() -> Self {
-        PathLocal(Rc::new(Vec::new()))
+        PathLocal(Vec::new().into())
     }
 
     fn create_prefix(&self, length: usize) -> Self {
@@ -146,7 +146,7 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> Path for PathLocal<MC
         }
 
         let until = std::cmp::min(length, self.0.len());
-        let slice = &self.0.as_slice()[0..until];
+        let slice = &self.0[0..until];
 
         Path::new(slice).unwrap()
     }
@@ -172,7 +172,7 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> Path for PathLocal<MC
 
         new_path_vec.push(component);
 
-        Ok(PathLocal(Rc::new(new_path_vec)))
+        Ok(PathLocal(new_path_vec.into()))
     }
 
     fn components(&self) -> impl Iterator<Item = &Self::Component> {


### PR DESCRIPTION
@AljoschaMeyer:

> we reached the first interesting decisions in the design of our Willow rust codebase. Basically: which sort of ownership model should the trait for Paths assume? Options we see:
> 
> 1. A Path trait whose implementors are cheaply clonable, immutable values. Featuring signatures such as Path::append(&self, component: component) -> Self and Path::make_prefix(&self, i: usize) -> Self.
> 2. A Path trait whose implementors are owned, mutable values. Featuring signatures such as Path::append(&mut self, component: component) and Path::as_prefix(&self, i: usize) -> &Self.
> 3. Two separate traits: a trait Path for immutable views of a path (think str) and a trait PathBuf for owned, mutating access (think String). Featuring signatures such as PathBuf::append(&mut self, component) and Path::as_prefix(&self, i: usize) -> Self, and with the PathBuf implementing AsRef for its associated type of Paths.

Option 2 turns out to be impossible:

> Here's a problem with option 2: you can't implement it. Imagine trying to write a function that takes a ref to a Vec and returns a ref to a prefix of that Vec - as a &Vec. Just doesn't work, you cannot store the length of the new vec anywhere with the correct lifetime. So Option 1 or 3 it is...

Option 3 is quite complex.

This PR contains changes to satisfy option 1 (clonable, immutable paths), in case we decide to go that way.

See #8 for the alternative