### PR TITLE
Range3d, Area, and AreaOfInterest

### DIFF
--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -106,15 +106,15 @@ mod tests {
 
     use super::*;
 
-    #[derive(Default, PartialEq, Eq)]
+    #[derive(Default, PartialEq, Eq, Clone)]
     struct FakeNamespaceId(usize);
     impl NamespaceId for FakeNamespaceId {}
 
-    #[derive(Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
     struct FakeSubspaceId(usize);
     impl SubspaceId for FakeSubspaceId {}
 
-    #[derive(Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
     struct FakePayloadDigest(usize);
     impl PayloadDigest for FakePayloadDigest {}
 

--- a/data-model/src/grouping/area.rs
+++ b/data-model/src/grouping/area.rs
@@ -97,11 +97,6 @@ impl<S: SubspaceId, P: Path> Area<S, P> {
             path,
         })
     }
-
-    /// Return a [`Range3d`] with equivalent inclusion to this [`Area`].
-    pub fn into_range(&self) -> Range3d<S, P> {
-        todo!("Need to add successor fns to SubspaceId and Paths first.")
-    }
 }
 
 #[cfg(test)]

--- a/data-model/src/grouping/area.rs
+++ b/data-model/src/grouping/area.rs
@@ -79,7 +79,7 @@ impl<S: SubspaceId, P: Path> Area<S, P> {
             && self.times.includes(&entry.timestamp)
     }
 
-    /// Return the intersection of two [`Area`]s.
+    /// Return the intersection of this [`Area`] with another.
     /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#area_intersection).
     pub fn intersection(&self, other: &Area<S, P>) -> Option<Self> {
         let subspace_id = self.subspace.intersection(&other.subspace)?;

--- a/data-model/src/grouping/area_of_interest.rs
+++ b/data-model/src/grouping/area_of_interest.rs
@@ -1,6 +1,4 @@
-use crate::{parameters::SubspaceId, path::Path};
-
-use super::area::Area;
+use crate::{grouping::area::Area, parameters::SubspaceId, path::Path};
 
 /// A grouping of [`Entry`]s that are among the newest in some [`Store`].
 /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#aois).
@@ -21,7 +19,7 @@ impl<S: SubspaceId, P: Path> AreaOfInterest<S, P> {
             None => None,
             Some(area_intersection) => Some(Self {
                 area: area_intersection,
-                max_count: self.max_count.min(other.max_count),
+                max_count: core::cmp::min(self.max_count, other.max_count),
                 max_size: self.max_size.min(other.max_size),
             }),
         }

--- a/data-model/src/grouping/area_of_interest.rs
+++ b/data-model/src/grouping/area_of_interest.rs
@@ -1,0 +1,29 @@
+use crate::{parameters::SubspaceId, path::Path};
+
+use super::area::Area;
+
+/// A grouping of [`Entry`]s that are among the newest in some [`Store`].
+/// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#aois).
+pub struct AreaOfInterest<S: SubspaceId, P: Path> {
+    /// To be included in this [`AreaOfInterest`], an [`Entry`] must be included in the [`Area`].
+    pub area: Area<S, P>,
+    /// To be included in this AreaOfInterest, an Entry’s timestamp must be among the max_count greatest Timestamps, unless max_count is zero.
+    pub max_count: u64,
+    /// The total payload_lengths of all included Entries is at most max_size, unless max_size is zero.
+    pub max_size: u64,
+}
+
+impl<S: SubspaceId, P: Path> AreaOfInterest<S, P> {
+    /// Return the intersection of this [`AreaOfInterest`] with another.
+    /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#aoi_intersection).
+    pub fn intersection(&self, other: AreaOfInterest<S, P>) -> Option<AreaOfInterest<S, P>> {
+        match self.area.intersection(&other.area) {
+            None => None,
+            Some(area_intersection) => Some(Self {
+                area: area_intersection,
+                max_count: self.max_count.min(other.max_count),
+                max_size: self.max_size.min(other.max_size),
+            }),
+        }
+    }
+}

--- a/data-model/src/grouping/mod.rs
+++ b/data-model/src/grouping/mod.rs
@@ -1,1 +1,2 @@
 pub mod range;
+pub mod range_3d;

--- a/data-model/src/grouping/mod.rs
+++ b/data-model/src/grouping/mod.rs
@@ -1,2 +1,3 @@
+pub mod area;
 pub mod range;
 pub mod range_3d;

--- a/data-model/src/grouping/mod.rs
+++ b/data-model/src/grouping/mod.rs
@@ -1,3 +1,4 @@
 pub mod area;
+pub mod area_of_interest;
 pub mod range;
 pub mod range_3d;

--- a/data-model/src/grouping/range.rs
+++ b/data-model/src/grouping/range.rs
@@ -77,8 +77,8 @@ where
     }
 
     /// Return whether a given value is [included](https://willowprotocol.org/specs/grouping-entries/index.html#range_include) by the [`Range`] or not.
-    pub fn includes(&self, value: T) -> bool {
-        self.start <= value && self.end.gt_val(&value)
+    pub fn includes(&self, value: &T) -> bool {
+        &self.start <= value && self.end.gt_val(value)
     }
 
     /// Returns `true` if `other` range is fully [included](https://willowprotocol.org/specs/grouping-entries/index.html#range_include) in this [`Range`].
@@ -167,15 +167,15 @@ mod tests {
     fn range_includes() {
         let open_range = Range::new_open(20);
 
-        assert!(open_range.includes(20));
-        assert!(open_range.includes(30));
-        assert!(!open_range.includes(10));
+        assert!(open_range.includes(&20));
+        assert!(open_range.includes(&30));
+        assert!(!open_range.includes(&10));
 
         let closed_range = Range::new_closed(5, 10).unwrap();
 
-        assert!(closed_range.includes(5));
-        assert!(closed_range.includes(8));
-        assert!(!closed_range.includes(1));
+        assert!(closed_range.includes(&5));
+        assert!(closed_range.includes(&8));
+        assert!(!closed_range.includes(&1));
     }
 
     #[test]

--- a/data-model/src/grouping/range_3d.rs
+++ b/data-model/src/grouping/range_3d.rs
@@ -31,7 +31,7 @@ impl<S: SubspaceId, P: Path> Range3d<S, P> {
             && self.times.includes(&entry.timestamp)
     }
 
-    /// Return the intersection between this [`Range3d`] and another [`Range3d`].
+    /// Return the intersection between this [`Range3d`] and another.
     pub fn intersection(&self, other: &Range3d<S, P>) -> Option<Self> {
         let paths = self.paths.intersection(&other.paths)?;
         let times = self.times.intersection(&other.times)?;

--- a/data-model/src/grouping/range_3d.rs
+++ b/data-model/src/grouping/range_3d.rs
@@ -65,7 +65,7 @@ mod tests {
     struct FakeNamespaceId(usize);
     impl NamespaceId for FakeNamespaceId {}
 
-    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
     struct FakeSubspaceId(usize);
     impl SubspaceId for FakeSubspaceId {}
 
@@ -139,5 +139,117 @@ mod tests {
         };
 
         assert!(!range_times_excluding.includes_entry(&entry));
+    }
+
+    #[test]
+    fn intersection() {
+        let empty_intersection_subspace = Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(11), FakeSubspaceId(13))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'1']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
+        }
+        .intersection(&Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'1']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
+        });
+
+        assert!(empty_intersection_subspace.is_none());
+
+        let empty_intersection_path = Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'1']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
+        }
+        .intersection(&Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'4']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'6']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
+        });
+
+        assert!(empty_intersection_path.is_none());
+
+        let empty_intersection_time = Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'1']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
+        }
+        .intersection(&Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'1']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(200, 300).unwrap(),
+        });
+
+        assert!(empty_intersection_time.is_none());
+
+        let intersection = Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'6']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
+        }
+        .intersection(&Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(2), FakeSubspaceId(4))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'3']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'9']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(50, 150).unwrap(),
+        });
+
+        assert!(intersection.is_some());
+
+        assert_eq!(
+            intersection.unwrap(),
+            Range3d {
+                subspaces: Range::<FakeSubspaceId>::new_closed(
+                    FakeSubspaceId(2),
+                    FakeSubspaceId(3)
+                )
+                .unwrap(),
+                paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                    PathRc::new(&[PathComponentBox::new(&[b'3']).unwrap()]).unwrap(),
+                    PathRc::new(&[PathComponentBox::new(&[b'6']).unwrap()]).unwrap(),
+                )
+                .unwrap(),
+                times: Range::<Timestamp>::new_closed(50, 100).unwrap(),
+            }
+        )
     }
 }

--- a/data-model/src/grouping/range_3d.rs
+++ b/data-model/src/grouping/range_3d.rs
@@ -1,6 +1,6 @@
-use super::range::Range;
 use crate::{
     entry::{Entry, Timestamp},
+    grouping::{area::Area, range::Range},
     parameters::{NamespaceId, PayloadDigest, SubspaceId},
     path::Path,
 };
@@ -48,10 +48,16 @@ impl<S: SubspaceId, P: Path> Default for Range3d<S, P> {
     /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#default_3d_range).
     fn default() -> Self {
         Self {
-            subspaces: Default::default(),
+            subspaces: Range::<S>::default(),
             paths: Range::new_open(P::empty()),
             times: Range::new_open(0),
         }
+    }
+}
+
+impl<S: SubspaceId, P: Path> From<Area<S, P>> for Range3d<S, P> {
+    fn from(_value: Area<S, P>) -> Self {
+        todo!("Need to add successor fns to SubspaceId and Paths first.")
     }
 }
 

--- a/data-model/src/grouping/range_3d.rs
+++ b/data-model/src/grouping/range_3d.rs
@@ -1,0 +1,143 @@
+use super::range::Range;
+use crate::{
+    entry::{Entry, Timestamp},
+    parameters::{NamespaceId, PayloadDigest, SubspaceId},
+    path::Path,
+};
+
+/// A three-dimensional range that includes every Entry included in all three of its ranges.
+/// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#D3Range).
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Range3d<S: SubspaceId, P: Path> {
+    /// A range of [`SubspaceId`]s.
+    /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#SubspaceRange).
+    pub subspaces: Range<S>,
+    /// A range of [`Path`]s.
+    /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#PathRange).
+    pub paths: Range<P>,
+    /// A range of [`Timestamp`]s.
+    /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#TimeRange).
+    pub times: Range<Timestamp>,
+}
+
+impl<S: SubspaceId, P: Path> Range3d<S, P> {
+    /// Return whether an [`Entry`] is [included](https://willowprotocol.org/specs/grouping-entries/index.html#d3_range_include) by this 3d range.
+    pub fn includes_entry<N: NamespaceId, PD: PayloadDigest>(
+        &self,
+        entry: &Entry<N, S, P, PD>,
+    ) -> bool {
+        self.subspaces.includes(&entry.subspace_id)
+            && self.paths.includes(&entry.path)
+            && self.times.includes(&entry.timestamp)
+    }
+
+    /// Return the intersection between this [`Range3d`] and another [`Range3d`].
+    pub fn intersection(&self, other: &Range3d<S, P>) -> Option<Self> {
+        let paths = self.paths.intersection(&other.paths)?;
+        let times = self.times.intersection(&other.times)?;
+        let subspaces = self.subspaces.intersection(&other.subspaces)?;
+        Some(Self {
+            paths,
+            times,
+            subspaces,
+        })
+    }
+}
+
+impl<S: SubspaceId, P: Path> Default for Range3d<S, P> {
+    /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#default_3d_range).
+    fn default() -> Self {
+        Self {
+            subspaces: Default::default(),
+            paths: Range::new_open(P::empty()),
+            times: Range::new_open(0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::path::{PathComponent, PathComponentBox, PathRc};
+
+    use super::*;
+
+    #[derive(Default, PartialEq, Eq, Clone)]
+    struct FakeNamespaceId(usize);
+    impl NamespaceId for FakeNamespaceId {}
+
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
+    struct FakeSubspaceId(usize);
+    impl SubspaceId for FakeSubspaceId {}
+
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
+    struct FakePayloadDigest(usize);
+    impl PayloadDigest for FakePayloadDigest {}
+
+    const MCL: usize = 8;
+    const MCC: usize = 4;
+    const MPL: usize = 16;
+
+    #[test]
+    fn includes_entry() {
+        let entry = Entry {
+            namespace_id: FakeNamespaceId::default(),
+            subspace_id: FakeSubspaceId(10),
+            path: PathRc::<MCL, MCC, MPL>::new(&[PathComponentBox::new(&[b'a']).unwrap()]).unwrap(),
+            timestamp: 500,
+            payload_length: 10,
+            payload_digest: FakePayloadDigest::default(),
+        };
+
+        let range_including = Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(9), FakeSubspaceId(11))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'b']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(400, 600).unwrap(),
+        };
+
+        assert!(range_including.includes_entry(&entry));
+
+        let range_subspaces_excluding = Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(11), FakeSubspaceId(13))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'b']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(400, 600).unwrap(),
+        };
+
+        assert!(!range_subspaces_excluding.includes_entry(&entry));
+
+        let range_paths_excluding = Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(9), FakeSubspaceId(11))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'1']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(400, 600).unwrap(),
+        };
+
+        assert!(!range_paths_excluding.includes_entry(&entry));
+
+        let range_times_excluding = Range3d {
+            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(9), FakeSubspaceId(11))
+                .unwrap(),
+            paths: Range::<PathRc<MCL, MCC, MPL>>::new_closed(
+                PathRc::new(&[PathComponentBox::new(&[b'0']).unwrap()]).unwrap(),
+                PathRc::new(&[PathComponentBox::new(&[b'b']).unwrap()]).unwrap(),
+            )
+            .unwrap(),
+            times: Range::<Timestamp>::new_closed(100, 200).unwrap(),
+        };
+
+        assert!(!range_times_excluding.includes_entry(&entry));
+    }
+}

--- a/data-model/src/parameters.rs
+++ b/data-model/src/parameters.rs
@@ -1,12 +1,9 @@
-use super::{
-    entry::{AuthorisedEntry, Entry, UnauthorisedWriteError},
-    path::Path,
-};
+use super::{entry::Entry, path::Path};
 
 /// A type for identifying [namespaces](https://willowprotocol.org/specs/data-model/index.html#namespace).
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#NamespaceId).
 
-pub trait NamespaceId: Eq + Default {}
+pub trait NamespaceId: Eq + Default + Clone {}
 
 /// A type for identifying [subspaces](https://willowprotocol.org/specs/data-model/index.html#subspace).
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#SubspaceId).
@@ -14,11 +11,11 @@ pub trait NamespaceId: Eq + Default {}
 /// ## Implementation notes
 ///
 /// The [`Default`] implementation **must** return the least element in the total order of [`SubspaceId`].
-pub trait SubspaceId: Ord + Default {}
+pub trait SubspaceId: Ord + Default + Clone {}
 
 /// A totally ordered type for [content-addressing](https://en.wikipedia.org/wiki/Content_addressing) the data that Willow stores.
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#PayloadDigest).
-pub trait PayloadDigest: Ord + Default {}
+pub trait PayloadDigest: Ord + Default + Clone {}
 
 /// A function that maps an [`Entry`] and an [`AuthorisationToken` (willowprotocol.org)](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) to a result indicating whether the `AuthorisationToken` does prove write permission for the [`Entry`].
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write).

--- a/data-model/src/parameters.rs
+++ b/data-model/src/parameters.rs
@@ -1,4 +1,4 @@
-use super::{entry::Entry, path::Path};
+use crate::{entry::Entry, path::Path};
 
 /// A type for identifying [namespaces](https://willowprotocol.org/specs/data-model/index.html#namespace).
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#NamespaceId).

--- a/data-model/src/path.rs
+++ b/data-model/src/path.rs
@@ -181,7 +181,7 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> Path for PathRc<MCL, 
             return Self::empty();
         }
 
-        let until = std::cmp::min(length, self.0.len());
+        let until = core::cmp::min(length, self.0.len());
         let slice = &self.0[0..until];
 
         Path::new(slice).unwrap()


### PR DESCRIPTION
## Implement `Range3d`

- Added `Range3d` struct with `includes_entry` and `intersection` methods, `Default` impl.
- `Range::includes` no longer moves the value being tested for inclusion
- Add Clone trait bound to NamespaceId, SubspaceId, PayloadDigest

## Implement `AreaSubspace`, `Area`

- Add `AreaSubspace` with `includes` and `intersection` methods
- Add `Area` with `full`, `subspace`, `includes_entry`, and `intersection` methods.

## Implement `AreaOfInterest`

- Add `AreaOfInterest` with `intersection` method.
