### PR TITLE
Rename IsAuthorisedWrite trait to AuthorisationToken

### DIFF
--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -5,7 +5,7 @@ use arbitrary::Arbitrary;
 
 use crate::{
     encoding::{DecodeError, U64BE},
-    parameters::{IsAuthorisedWrite, NamespaceId, PayloadDigest, SubspaceId},
+    parameters::{AuthorisationToken, NamespaceId, PayloadDigest, SubspaceId},
     path::Path,
 };
 
@@ -254,7 +254,7 @@ where
         token: AT,
     ) -> Result<Self, UnauthorisedWriteError>
     where
-        AT: IsAuthorisedWrite<MCL, MCC, MPL, N, S, PD>,
+        AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
     {
         if token.is_authorised_write(&entry) {
             return Ok(Self(entry, token));

--- a/data-model/src/parameters.rs
+++ b/data-model/src/parameters.rs
@@ -28,7 +28,7 @@ pub trait PayloadDigest: Ord + Default + Clone {}
 /// - `N` - The type used for the [`Entry`]'s [`NamespaceId`].
 /// - `S` - The type used for the [`Entry`]'s [`SubspaceId`].
 /// - `PD` - The type used for the [`Entry`]'s [`PayloadDigest`].
-pub trait IsAuthorisedWrite<
+pub trait AuthorisationToken<
     const MCL: usize,
     const MCC: usize,
     const MPL: usize,

--- a/fuzz/fuzz_targets/mc_is_authorised_write.rs
+++ b/fuzz/fuzz_targets/mc_is_authorised_write.rs
@@ -5,8 +5,8 @@ use meadowcap::{AccessMode, McAuthorisationToken};
 use signature::Signer;
 use ufotofu::sync::consumer::IntoVec;
 use willow_data_model::encoding::sync::Encodable;
+use willow_data_model::AuthorisationToken;
 use willow_data_model::Entry;
-use willow_data_model::IsAuthorisedWrite;
 use willow_fuzz::{
     placeholder_params::FakePayloadDigest,
     silly_sigs::{SillyPublicKey, SillySig},

--- a/meadowcap/src/mc_authorisation_token.rs
+++ b/meadowcap/src/mc_authorisation_token.rs
@@ -1,12 +1,12 @@
 use signature::Verifier;
 use ufotofu::sync::consumer::IntoVec;
 use willow_data_model::{
-    encoding::sync::Encodable, Entry, IsAuthorisedWrite, NamespaceId, PayloadDigest, SubspaceId,
+    encoding::sync::Encodable, AuthorisationToken, Entry, NamespaceId, PayloadDigest, SubspaceId,
 };
 
 use crate::{mc_capability::McCapability, AccessMode, IsCommunal};
 
-/// To be used as an AuthorisationToken for Willow.
+/// To be used as the [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) parameter for the [Willow data model](https://willowprotocol.org/specs/data-model).
 ///
 /// [Definition](https://willowprotocol.org/specs/meadowcap/index.html#MeadowcapAuthorisationToken)
 #[derive(Debug, Clone)]
@@ -47,7 +47,7 @@ impl<
         UserPublicKey,
         UserSignature,
         PD,
-    > IsAuthorisedWrite<MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, PD>
+    > AuthorisationToken<MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, PD>
     for McAuthorisationToken<
         MCL,
         MCC,


### PR DESCRIPTION
Renames the `IsAuthorisedWrite` trait to `AuthorisationToken` for consistency with `NamespaceId` and other parameter friends.