### PR TITLE
Willow data model + Meadowcap docs polishing

### DIFF
--- a/data-model/src/encoding/bytes.rs
+++ b/data-model/src/encoding/bytes.rs
@@ -26,6 +26,7 @@ pub mod encoding {
     }
 }
 
+/// Return whether a bit at the given position is `1` or not.
 pub fn is_bitflagged(byte: u8, position: u8) -> bool {
     let mask = match position {
         0 => 0b1000_0000,

--- a/data-model/src/encoding/compact_width.rs
+++ b/data-model/src/encoding/compact_width.rs
@@ -1,6 +1,8 @@
 use crate::encoding::error::DecodeError;
 
 /// A minimum width of bytes needed to represent a unsigned integer.
+///
+/// [Definition](https://willowprotocol.org/specs/encodings/index.html#compact_width)
 #[derive(PartialEq, Eq, Debug)]
 pub enum CompactWidth {
     /// The byte-width required to represent numbers up to 256 (i.e. a 8-bit number).

--- a/data-model/src/encoding/compact_width.rs
+++ b/data-model/src/encoding/compact_width.rs
@@ -76,7 +76,7 @@ impl CompactWidth {
         CompactWidth::One
     }
 
-    /// Return the width in bytes of this [`CompactSize`].
+    /// Return the width in bytes of this [`CompactWidth`].
     pub fn width(&self) -> usize {
         match self {
             CompactWidth::One => 1,

--- a/data-model/src/encoding/compact_width.rs
+++ b/data-model/src/encoding/compact_width.rs
@@ -137,7 +137,7 @@ pub mod encoding {
         Ok(())
     }
 
-    /// Decode the bytes representing a [`compact-width`]-bytes integer into a `usize`.
+    /// Decode the bytes representing a [`CompactWidth`]-bytes integer into a `usize`.
     pub async fn decode_compact_width_be<Producer: BulkProducer<Item = u8>>(
         compact_width: CompactWidth,
         producer: &mut Producer,

--- a/data-model/src/encoding/mod.rs
+++ b/data-model/src/encoding/mod.rs
@@ -1,3 +1,5 @@
+//! Utilities for implementing Willow's various [encodings](https://willowprotocol.org/specs/encodings/index.html#encodings).
+
 mod bytes;
 mod compact_width;
 mod error;
@@ -25,6 +27,8 @@ pub use unsigned_int::*;
 pub use max_power::{decode_max_power, encode_max_power, max_power};
 
 pub mod sync {
+    //! Synchronous variants of utilities for implementing Willow's various [encodings](https://willowprotocol.org/specs/encodings/index.html#encodings).
+
     pub use super::bytes::encoding_sync::produce_byte;
     pub use super::compact_width::encoding_sync::*;
     pub use super::max_power::encoding_sync::*;

--- a/data-model/src/encoding/unsigned_int.rs
+++ b/data-model/src/encoding/unsigned_int.rs
@@ -2,7 +2,7 @@ use crate::encoding::error::DecodeError;
 
 use core::mem::size_of;
 
-/// A `u8` wrapper that implements [`Encoding`] and [`Decoding`] by encoding as a big-endian fixed-width integer.
+/// A `u8` wrapper that implements [`crate::encoding::Encodable`] and [`crate::encoding::Decodable`] by encoding as a big-endian fixed-width integer.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct U8BE(u8);
 
@@ -18,7 +18,7 @@ impl From<U8BE> for u64 {
     }
 }
 
-/// A `u16` wrapper that implements [`Encoding`] and [`Decoding`] by encoding as a big-endian fixed-width integer.
+/// A `u16` wrapper that implements [`crate::encoding::Encodable`] and [`crate::encoding::Decodable`] by encoding as a big-endian fixed-width integer.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct U16BE(u16);
 
@@ -34,7 +34,7 @@ impl From<U16BE> for u64 {
     }
 }
 
-/// A `u32` wrapper that implements [`Encoding`] and [`Decoding`] by encoding as a big-endian fixed-width integer.
+/// A `u32` wrapper that implements [`crate::encoding::Encodable`] and [`crate::encoding::Decodable`] by encoding as a big-endian fixed-width integer.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct U32BE(u32);
 
@@ -50,7 +50,7 @@ impl From<U32BE> for u64 {
     }
 }
 
-/// A `u64` wrapper that implements [`Encoding`] and [`Decoding`] by encoding as a big-endian fixed-width integer.
+/// A `u64` wrapper that implements [`crate::encoding::Encodable`] and [`crate::encoding::Decodable`] by encoding as a big-endian fixed-width integer.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct U64BE(u64);
 

--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -217,11 +217,12 @@ where
     }
 }
 
-/// An error indicating an [`AuthorisationToken`] does not authorise the writing of this entry.
+/// An error indicating an [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) does not authorise the writing of this entry.
 #[derive(Debug)]
 pub struct UnauthorisedWriteError;
 
-/// An AuthorisedEntry is a pair of an [`Entry`] and [`AuthorisationToken`] for which [`Entry::is_authorised_write`] returns true.
+/// An AuthorisedEntry is a pair of an [`Entry`] and [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) implementing [`IsAuthorisedWrite`] for which [`is_authorised_write`](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write) returns true.
+///
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#AuthorisedEntry).
 ///
 /// ## Type parameters

--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -214,7 +214,7 @@ where
 #[derive(Debug)]
 pub struct UnauthorisedWriteError;
 
-/// An AuthorisedEntry is a pair of an [`Entry`] and [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) implementing [`IsAuthorisedWrite`] for which [`is_authorised_write`](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write) returns true.
+/// An AuthorisedEntry is a pair of an [`Entry`] and [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) (willowprotocol.org) implementing [`AuthorisationToken`] for which [`is_authorised_write`](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write) returns true.
 ///
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#AuthorisedEntry).
 pub struct AuthorisedEntry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>(

--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -16,13 +16,6 @@ pub type Timestamp = u64;
 
 /// The metadata associated with each Payload.
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#Entry).
-///
-/// ## Type parameters
-///
-/// - `N` - The type used for [`NamespaceId`].
-/// - `S` - The type used for [`SubspaceId`].
-/// - `P` - The type used for [`Path`]s.
-/// - `PD` - The type used for [`PayloadDigest`].
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Entry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>
 where
@@ -224,14 +217,6 @@ pub struct UnauthorisedWriteError;
 /// An AuthorisedEntry is a pair of an [`Entry`] and [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) implementing [`IsAuthorisedWrite`] for which [`is_authorised_write`](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write) returns true.
 ///
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#AuthorisedEntry).
-///
-/// ## Type parameters
-///
-/// - `N` - The type used for [`NamespaceId`].
-/// - `S` - The type used for [`SubspaceId`].
-/// - `P` - The type used for [`Path`]s.
-/// - `PD` - The type used for [`PayloadDigest`].
-/// - `AT` - The type used for the [`AuthorisationToken` (willowprotocol.org)](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken).
 pub struct AuthorisedEntry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>(
     pub Entry<MCL, MCC, MPL, N, S, PD>,
     pub AT,

--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// A Timestamp is a 64-bit unsigned integer, that is, a natural number between zero (inclusive) and 2^64 - 1 (exclusive).
 /// Timestamps are to be interpreted as a time in microseconds since the Unix epoch.
-/// [Read more](https://willowprotocol.org/specs/data-model/index.html#Timestamp).
+/// [Definition](https://willowprotocol.org/specs/data-model/index.html#Timestamp).
 pub type Timestamp = u64;
 
 /// The metadata associated with each Payload.

--- a/data-model/src/grouping/area_of_interest.rs
+++ b/data-model/src/grouping/area_of_interest.rs
@@ -1,9 +1,10 @@
 use crate::{grouping::area::Area, parameters::SubspaceId};
 
-/// A grouping of [`Entry`]s that are among the newest in some [`Store`].
+/// A grouping of [`crate::Entry`]s that are among the newest in some [store](https://willowprotocol.org/specs/data-model/index.html#store).
+///
 /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#aois).
 pub struct AreaOfInterest<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> {
-    /// To be included in this [`AreaOfInterest`], an [`Entry`] must be included in the [`Area`].
+    /// To be included in this [`AreaOfInterest`], an [`crate::Entry`] must be included in the [`Area`].
     pub area: Area<MCL, MCC, MPL, S>,
     /// To be included in this AreaOfInterest, an Entry’s timestamp must be among the max_count greatest Timestamps, unless max_count is zero.
     pub max_count: u64,

--- a/data-model/src/grouping/mod.rs
+++ b/data-model/src/grouping/mod.rs
@@ -1,3 +1,4 @@
+//! Utilities for Willow's entry [groupings](https://willowprotocol.org/specs/grouping-entries/index.html#grouping_entries).
 mod area;
 pub use area::*;
 mod area_of_interest;

--- a/data-model/src/lib.rs
+++ b/data-model/src/lib.rs
@@ -9,6 +9,20 @@
 //! - Utilities for encoding and decoding, as well as implementations of all of Willow's [encodings](https://willowprotocol.org/specs/encodings/index.html#encodings).
 //!
 //! This crate **does not yet have** anything for Willow's concept of [stores](https://willowprotocol.org/specs/data-model/index.html#store). Stay tuned!
+//!
+//! ## Type parameters
+//!
+//! Willow is a parametrised family of protocols, and so this crate makes heavy use of generic parameters.
+//!
+//! The following generic parameter names are used consistently across this crate:
+//!
+//! - `MCL` - A `usize` representing [`max_component_length`](https://willowprotocol.org/specs/data-model/index.html#max_component_length).
+//! - `MCC` - A `usize` representing [`max_component_count`](https://willowprotocol.org/specs/data-model/index.html#max_component_count).
+//! - `MPL` - A `usize` representing [`max_path_length`](https://willowprotocol.org/specs/data-model/index.html#max_path_length).
+//! - `N` - The type used for [`NamespaceId`](https://willowprotocol.org/specs/data-model/index.html#NamespaceId) (willowprotocol.org), must implement the [`NamespaceId`] trait.
+//! - `S` - The type used for [`SubspaceId`](https://willowprotocol.org/specs/data-model/index.html#SubspaceId) (willowprotocol.org), must implement the [`SubspaceId`] trait.
+//! - `PD` - The type used for [`PayloadDigest`](https://willowprotocol.org/specs/data-model/index.html#PayloadDigest) (willowprotocol.org), must implement the [`PayloadDigest`] trait.
+//! - `AT` - The type used for [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) (willowprotocol.org), must implement the [`AuthorisationToken`] trait.
 
 #![feature(
     new_uninit,

--- a/data-model/src/lib.rs
+++ b/data-model/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://willowprotocol.org/named_assets/willow_emblem_standalone.png")]
 //! # Willow Data Model
 //!
 //! This crate provides implementation of the [Willow Data Model](https://willowprotocol.org/specs/data-model/index.html#data_model), including:

--- a/data-model/src/lib.rs
+++ b/data-model/src/lib.rs
@@ -1,4 +1,14 @@
-//! Allo!
+//! # Willow Data Model
+//!
+//! This crate provides implementation of the [Willow Data Model](https://willowprotocol.org/specs/data-model/index.html#data_model), including:
+//!
+//! - Traits to assist in your implementation of Willow [parameters](https://willowprotocol.org/specs/data-model/index.html#willow_parameters), such as [`NamespaceId`](https://willowprotocol.org/specs/data-model/index.html#NamespaceId) and [`SubspaceId`](https://willowprotocol.org/specs/data-model/index.html#SubspaceId).  
+//! - A [zero-copy](https://en.wikipedia.org/wiki/Zero-copy) implementation of Willow [paths](https://willowprotocol.org/specs/data-model/index.html#Path) and their constituent [components](https://willowprotocol.org/specs/data-model/index.html#Component).
+//! - An implementation of Willow's [entries](https://willowprotocol.org/specs/data-model/index.html#Entry).
+//! - Utilities for Willow's entry [groupings](https://willowprotocol.org/specs/grouping-entries/index.html#grouping_entries), such as [ranges](https://willowprotocol.org/specs/grouping-entries/index.html#ranges) and [areas](https://willowprotocol.org/specs/grouping-entries/index.html#areas)
+//! - Utilities for encoding and decoding, as well as implementations of all of Willow's [encodings](https://willowprotocol.org/specs/encodings/index.html#encodings).
+//!
+//! This crate **does not yet have** anything for Willow's concept of [stores](https://willowprotocol.org/specs/data-model/index.html#store). Stay tuned!
 
 #![feature(
     new_uninit,
@@ -13,9 +23,7 @@ pub mod encoding;
 mod entry;
 pub use entry::*;
 pub mod grouping;
-
 mod parameters;
 pub use parameters::*;
-
 mod path;
 pub use path::*;

--- a/meadowcap/src/communal_capability.rs
+++ b/meadowcap/src/communal_capability.rs
@@ -46,7 +46,7 @@ where
     UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
     UserSignature: Encodable + Clone,
 {
-    /// Create a new communal capability granting access to the [`SubspaceId`] corresponding to the given [`UserPublicKey`].
+    /// Create a new communal capability granting access to the [`SubspaceId`] corresponding to the given `UserPublicKey`.
     pub fn new(
         namespace_key: NamespacePublicKey,
         user_key: UserPublicKey,
@@ -64,7 +64,7 @@ where
         })
     }
 
-    /// Delegate this capability to a new [`UserPublicKey`] for a given [`Area`].
+    /// Delegate this capability to a new `UserPublicKey` for a given [`willow_data_model::grouping::Area`].
     /// Will fail if the area is not included by this capability's [granted area](https://willowprotocol.org/specs/meadowcap/index.html#communal_cap_granted_area), or if the given secret key does not correspond to the capability's [receiver](https://willowprotocol.org/specs/meadowcap/index.html#communal_cap_receiver).
     pub fn delegate<UserSecretKey>(
         &self,

--- a/meadowcap/src/communal_capability.rs
+++ b/meadowcap/src/communal_capability.rs
@@ -8,7 +8,7 @@ use willow_data_model::{
 
 use crate::{AccessMode, Delegation, FailedDelegationError, InvalidDelegationError, IsCommunal};
 
-/// Returned when [`is_communal`](https://willowprotocol.org/specs/meadowcap/index.html#is_communal) unexpectedly mapped a given namespace to `false`.
+/// Returned when [`is_communal`](https://willowprotocol.org/specs/meadowcap/index.html#is_communal) unexpectedly mapped a given [`namespace`](https://willowprotocol.org/specs/data-model/index.html#namespace) to `false`.
 pub struct NamespaceIsNotCommunalError<NamespacePublicKey>(NamespacePublicKey);
 
 /// A capability that implements [communal namespaces](https://willowprotocol.org/specs/meadowcap/index.html#communal_namespace).

--- a/meadowcap/src/lib.rs
+++ b/meadowcap/src/lib.rs
@@ -1,3 +1,9 @@
+//! # Meadowcap
+//!
+//! An implementation of [Meadowcap](https://willowprotocol.org/specs/meadowcap/index.html#meadowcap), a capability system for permissioning read and write access to the [Willow data model](https://willowprotocol.org/specs/data-model/index.html#data_model).
+//!
+//! Includes implementations of [communal capabilities](https://willowprotocol.org/specs/meadowcap/index.html#communal_capabilities), [owned capabilities](https://willowprotocol.org/specs/meadowcap/index.html#owned_capabilities), and a type [unifying the two](https://willowprotocol.org/specs/meadowcap/index.html#proper_capabilities), as well as the generation of [`McAuthorisationTokens`](https://willowprotocol.org/specs/meadowcap/index.html#MeadowcapAuthorisationToken) for use with the Willow data model's [`is_authorised_write`](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write) parameter.
+
 use willow_data_model::{grouping::Area, SubspaceId};
 
 /// Maps namespace public keys to booleans, determining whether that namespace of a particular [`willow_data_model::NamespaceId`] is [communal](https://willowprotocol.org/specs/meadowcap/index.html#communal_namespace) or [owned](https://willowprotocol.org/specs/meadowcap/index.html#owned_namespace).

--- a/meadowcap/src/lib.rs
+++ b/meadowcap/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_logo_url = "https://willowprotocol.org/named_assets/meadowcap_emblem_standalone.png")]
 //! # Meadowcap
 //!
 //! An implementation of [Meadowcap](https://willowprotocol.org/specs/meadowcap/index.html#meadowcap), a capability system for permissioning read and write access to the [Willow data model](https://willowprotocol.org/specs/data-model/index.html#data_model).

--- a/meadowcap/src/lib.rs
+++ b/meadowcap/src/lib.rs
@@ -3,6 +3,21 @@
 //! An implementation of [Meadowcap](https://willowprotocol.org/specs/meadowcap/index.html#meadowcap), a capability system for permissioning read and write access to the [Willow data model](https://willowprotocol.org/specs/data-model/index.html#data_model).
 //!
 //! Includes implementations of [communal capabilities](https://willowprotocol.org/specs/meadowcap/index.html#communal_capabilities), [owned capabilities](https://willowprotocol.org/specs/meadowcap/index.html#owned_capabilities), a type [unifying the two](https://willowprotocol.org/specs/meadowcap/index.html#proper_capabilities), as well as the generation of [`McAuthorisationTokens`](https://willowprotocol.org/specs/meadowcap/index.html#MeadowcapAuthorisationToken) for use with the Willow data model's [`is_authorised_write`](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write) parameter.
+//!
+//! ## Type parameters
+//!
+//! Willow is a parametrised family of protocols, and so this crate makes heavy use of generic parameters.
+//!
+//! The following generic parameter names are used consistently across this crate:
+//!
+//! - `MCL` - A `usize` representing [`max_component_length`](https://willowprotocol.org/specs/data-model/index.html#max_component_length).
+//! - `MCC` - A `usize` representing [`max_component_count`](https://willowprotocol.org/specs/data-model/index.html#max_component_count).
+//! - `MPL` - A `usize` representing [`max_path_length`](https://willowprotocol.org/specs/data-model/index.html#max_path_length).
+//! - `NamespacePublicKey` - The type used for [`NamespacePublicKey`](https://willowprotocol.org/specs/meadowcap/index.html#NamespacePublicKey) (willowprotocol.org), must implement the [`willow_data_model::NamespaceId`] trait.
+//! - `NamespaceSignature` - The type used for [`NamespaceSignature`](https://willowprotocol.org/specs/meadowcap/index.html#NamespaceSignature) (willowprotocol.org).
+//! - `UserPublicKey` - The type used for [`UserPublicKey`](https://willowprotocol.org/specs/meadowcap/index.html#UserPublicKey) (willowprotocol.org), must implement the [`SubspaceId`] trait.
+//! - `UserSignature` - The type used for [`UserSignature`](https://willowprotocol.org/specs/meadowcap/index.html#UserSignature) (willowprotocol.org).
+//! - `PD` - The type used for [`PayloadDigest`](https://willowprotocol.org/specs/data-model/index.html#PayloadDigest) (willowprotocol.org), must implement the [`willow_data_model::PayloadDigest`] trait.
 
 use willow_data_model::{grouping::Area, SubspaceId};
 

--- a/meadowcap/src/lib.rs
+++ b/meadowcap/src/lib.rs
@@ -2,16 +2,16 @@
 //!
 //! An implementation of [Meadowcap](https://willowprotocol.org/specs/meadowcap/index.html#meadowcap), a capability system for permissioning read and write access to the [Willow data model](https://willowprotocol.org/specs/data-model/index.html#data_model).
 //!
-//! Includes implementations of [communal capabilities](https://willowprotocol.org/specs/meadowcap/index.html#communal_capabilities), [owned capabilities](https://willowprotocol.org/specs/meadowcap/index.html#owned_capabilities), and a type [unifying the two](https://willowprotocol.org/specs/meadowcap/index.html#proper_capabilities), as well as the generation of [`McAuthorisationTokens`](https://willowprotocol.org/specs/meadowcap/index.html#MeadowcapAuthorisationToken) for use with the Willow data model's [`is_authorised_write`](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write) parameter.
+//! Includes implementations of [communal capabilities](https://willowprotocol.org/specs/meadowcap/index.html#communal_capabilities), [owned capabilities](https://willowprotocol.org/specs/meadowcap/index.html#owned_capabilities), a type [unifying the two](https://willowprotocol.org/specs/meadowcap/index.html#proper_capabilities), as well as the generation of [`McAuthorisationTokens`](https://willowprotocol.org/specs/meadowcap/index.html#MeadowcapAuthorisationToken) for use with the Willow data model's [`is_authorised_write`](https://willowprotocol.org/specs/data-model/index.html#is_authorised_write) parameter.
 
 use willow_data_model::{grouping::Area, SubspaceId};
 
-/// Maps namespace public keys to booleans, determining whether that namespace of a particular [`willow_data_model::NamespaceId`] is [communal](https://willowprotocol.org/specs/meadowcap/index.html#communal_namespace) or [owned](https://willowprotocol.org/specs/meadowcap/index.html#owned_namespace).
+/// Maps [namespace](https://willowprotocol.org/specs/data-model/index.html#namespace) public keys to booleans, determining whether that namespace of a particular [`willow_data_model::NamespaceId`] is [communal](https://willowprotocol.org/specs/meadowcap/index.html#communal_namespace) or [owned](https://willowprotocol.org/specs/meadowcap/index.html#owned_namespace).
 pub trait IsCommunal {
     fn is_communal(&self) -> bool;
 }
 
-/// A delegation of access rights to a user for a given area.
+/// A delegation of access rights to a user for a given [area](https://willowprotocol.org/specs/grouping-entries/index.html#areas).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Delegation<
     const MCL: usize,
@@ -103,7 +103,7 @@ impl<'a> Arbitrary<'a> for AccessMode {
     }
 }
 
-/// Returned when an attempt to delegate a capability failed.
+/// Returned when an attempt to delegate a capability to another `UserPublicKey` failed.
 #[derive(Debug)]
 pub enum FailedDelegationError<
     const MCL: usize,
@@ -120,7 +120,7 @@ pub enum FailedDelegationError<
     WrongSecretForUser(UserPublicKey),
 }
 
-/// Returned when an existing delegation was found to be invalid.
+/// Returned when an existing delegation was an invalid successor to an existing delegation chain.
 #[derive(Debug)]
 pub enum InvalidDelegationError<
     const MCL: usize,

--- a/meadowcap/src/mc_authorisation_token.rs
+++ b/meadowcap/src/mc_authorisation_token.rs
@@ -6,7 +6,7 @@ use willow_data_model::{
 
 use crate::{mc_capability::McCapability, AccessMode, IsCommunal};
 
-/// To be used as an AuthorisationToken for Willow.
+/// To be used as the [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) parameter for the [Willow data model](https://willowprotocol.org/specs/data-model).
 ///
 /// [Definition](https://willowprotocol.org/specs/meadowcap/index.html#MeadowcapAuthorisationToken)
 #[derive(Debug, Clone)]

--- a/meadowcap/src/mc_capability.rs
+++ b/meadowcap/src/mc_capability.rs
@@ -75,7 +75,7 @@ where
     NamespaceSignature: Encodable + Clone,
     UserSignature: Encodable + Clone,
 {
-    /// Create a new communal capability granting access to the [`SubspaceId`] corresponding to the given [`UserPublicKey`], or return an error if the namespace key is not communal.
+    /// Create a new communal capability granting access to the [`SubspaceId`] corresponding to the given `UserPublicKey`, or return an error if the namespace key is not communal.
     pub fn new_communal(
         namespace_key: NamespacePublicKey,
         user_key: UserPublicKey,
@@ -85,7 +85,7 @@ where
         Ok(Self::Communal(cap))
     }
 
-    /// Create a new owned capability granting access to the [full area](https://willowprotocol.org/specs/grouping-entries/index.html#full_area) of the [namespace](https://willowprotocol.org/specs/data-model/index.html#namespace) to the given [`UserPublicKey`].
+    /// Create a new owned capability granting access to the [full area](https://willowprotocol.org/specs/grouping-entries/index.html#full_area) of the [namespace](https://willowprotocol.org/specs/data-model/index.html#namespace) to the given `UserPublicKey`.
     pub async fn new_owned<NamespaceSecret>(
         namespace_key: NamespacePublicKey,
         namespace_secret: NamespaceSecret,
@@ -159,7 +159,7 @@ where
         }
     }
 
-    /// Delegate this capability to a new [`UserPublicKey`] for a given [`Area`].
+    /// Delegate this capability to a new `UserPublicKey` for a given [`willow_data_model::grouping::Area`].
     /// Will fail if the area is not included by this capability's granted area, or if the given secret key does not correspond to the capability's receiver.
     pub fn delegate<UserSecretKey>(
         &self,
@@ -238,7 +238,7 @@ where
         }
     }
 
-    /// Return a new [`AuthorisationToken`], or an error if the resulting signature was not for the capability's receiver.
+    /// Return a new [`McAuthorisationToken`], or an error if the resulting signature was not for the capability's receiver.
     pub fn authorisation_token<UserSecret, PD>(
         &self,
         entry: Entry<MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, PD>,

--- a/meadowcap/src/mc_capability.rs
+++ b/meadowcap/src/mc_capability.rs
@@ -14,7 +14,7 @@ use crate::{
     AccessMode, Delegation, FailedDelegationError, InvalidDelegationError, IsCommunal,
 };
 
-/// Returned when an operation which should have been called on a write capability was called on a read capability.
+/// Returned when an operation only applicable to a capability with access mode [`AccessMode::Write`] was called on a capability with access mode [`AccessMode::Read`].
 #[derive(Debug)]
 pub struct NotAWriteCapabilityError;
 

--- a/meadowcap/src/mc_subspace_capability.rs
+++ b/meadowcap/src/mc_subspace_capability.rs
@@ -141,7 +141,7 @@ where
         &self.namespace_key
     }
 
-    /// Delegate this subspace capability to a new [`UserPublicKey`].
+    /// Delegate this subspace capability to a new `UserPublicKey`.
     /// Will fail if the given secret key does not correspond to the subspace capability's [receiver](https://willowprotocol.org/specs/meadowcap/index.html#communal_cap_receiver).
     pub fn delegate<UserSecretKey>(
         &self,
@@ -189,7 +189,7 @@ where
         Ok(())
     }
 
-    /// Return a slice of all [`Delegation`]s made to this capability.
+    /// Return a slice of all [`SubspaceDelegation`]s made to this capability.
     pub fn delegations(
         &self,
     ) -> impl Iterator<Item = &SubspaceDelegation<UserPublicKey, UserSignature>> {

--- a/meadowcap/src/mc_subspace_capability.rs
+++ b/meadowcap/src/mc_subspace_capability.rs
@@ -9,7 +9,7 @@ use crate::IsCommunal;
 #[cfg(feature = "dev")]
 use arbitrary::{Arbitrary, Error as ArbitraryError};
 
-/// A delegation of read access for arbitrary SubspaceIds to a user.
+/// A [delegation](https://willowprotocol.org/specs/pai/index.html#subspace_cap_delegations) of read access for arbitrary `SubspaceId`s to a `UserPublicKey`.
 #[derive(Clone, Debug, PartialEq, Eq, Arbitrary)]
 pub struct SubspaceDelegation<UserPublicKey, UserSignature>
 where

--- a/meadowcap/src/owned_capability.rs
+++ b/meadowcap/src/owned_capability.rs
@@ -65,7 +65,7 @@ where
     UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
     UserSignature: Encodable + Clone,
 {
-    /// Create a new owned capability granting access to the [full area](https://willowprotocol.org/specs/grouping-entries/index.html#full_area) of the [namespace](https://willowprotocol.org/specs/data-model/index.html#namespace) to the given [`UserPublicKey`].
+    /// Create a new owned capability granting access to the [full area](https://willowprotocol.org/specs/grouping-entries/index.html#full_area) of the [namespace](https://willowprotocol.org/specs/data-model/index.html#namespace) to the given `UserPublicKey`.
     pub fn new<NamespaceSecret>(
         namespace_key: NamespacePublicKey,
         namespace_secret: NamespaceSecret,
@@ -141,7 +141,7 @@ where
         })
     }
 
-    /// Delegate this capability to a new [`UserPublicKey`] for a given [`Area`].
+    /// Delegate this capability to a new `UserPublicKey` for a given [`willow_data_model::grouping::Area`].
     /// Will fail if the area is not included by this capability's [granted area](https://willowprotocol.org/specs/meadowcap/index.html#communal_cap_granted_area), or if the given secret key does not correspond to the capability's [receiver](https://willowprotocol.org/specs/meadowcap/index.html#communal_cap_receiver).
     pub fn delegate<UserSecretKey>(
         &self,
@@ -187,7 +187,7 @@ where
         })
     }
 
-    /// Return whether this capability needs a complementing [`McSubspaceCapability`] ((definition))[https://willowprotocol.org/specs/pai/index.html#subspace_capability] to in order to be fully authorised by the Willow General Sync Protocol.
+    /// Return whether this capability needs a complementing [`crate::McSubspaceCapability`] [(definition)](https://willowprotocol.org/specs/pai/index.html#subspace_capability) to in order to be fully authorised by the Willow General Sync Protocol.
     pub fn needs_subspace_cap(&self) -> bool {
         if self.access_mode == AccessMode::Write {
             return false;


### PR DESCRIPTION
Adds top-level crate documentation, adds documentation on type parameters, improves some documentation, fixes some doc linting issues, and of course adds logos to the docs too.