### PR TITLE
fix: feature flag arbitrary imports

### DIFF
--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "dev")]
-use arbitrary::size_hint::and_all;
-#[cfg(feature = "dev")]
-use arbitrary::Arbitrary;
+use arbitrary::{size_hint::and_all, Arbitrary};
 
 use crate::{
     encoding::{DecodeError, U64BE},

--- a/data-model/src/grouping/area.rs
+++ b/data-model/src/grouping/area.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "dev")]
 use arbitrary::{size_hint::and_all, Arbitrary};
 
 use crate::{

--- a/data-model/src/grouping/range.rs
+++ b/data-model/src/grouping/range.rs
@@ -1,6 +1,7 @@
 use core::cmp;
 use core::cmp::Ordering;
 
+#[cfg(feature = "dev")]
 use arbitrary::{Arbitrary, Error as ArbitraryError};
 
 use crate::path::Path;

--- a/data-model/src/grouping/range_3d.rs
+++ b/data-model/src/grouping/range_3d.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "dev")]
 use arbitrary::Arbitrary;
 
 use crate::{


### PR DESCRIPTION
Quick fix to the feature flags to make `willow-data-model` compile without the `dev` feature.