### PR TITLE
Make willow-data-model + meadowcap crates no longer require nightly channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,9 +502,9 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "ufotofu"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafc480c70cf5b56fe8c9132b850951ec14880b6e0a2c96b9a6cda1717c289a7"
+checksum = "c773ca845a07603d8ebe7292a3cefa20bf41305ce91246332c7fc1e3029eecaa"
 dependencies = [
  "arbitrary",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,26 +485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror-core"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c001ee18b7e5e3f62cbf58c7fe220119e68d902bb7443179c0c8aef30090e999"
-dependencies = [
- "thiserror-core-impl",
-]
-
-[[package]]
-name = "thiserror-core-impl"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,35 +501,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
-name = "trait-variant"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ufotofu"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d1fbdc439b2d48e0725dfe321025033d587530e74a1d7924c32e5e9f2d957a"
+checksum = "fafc480c70cf5b56fe8c9132b850951ec14880b6e0a2c96b9a6cda1717c289a7"
 dependencies = [
  "arbitrary",
  "either",
- "thiserror-core",
- "trait-variant",
  "ufotofu_queues",
  "wrapper",
 ]
 
 [[package]]
 name = "ufotofu_queues"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5ff287c701ff2a205cbafeaa78d691850ebb7ad91262f052b0495aff4c06d9"
+checksum = "d903d5bc0e14d24559dac3b9690d004ad3fb08d66f93d87d28f5cb3466b5b55b"
 
 [[package]]
 name = "unicode-ident"

--- a/data-model/Cargo.toml
+++ b/data-model/Cargo.toml
@@ -10,7 +10,7 @@ dev = ["dep:arbitrary"]
 [dependencies]
 either = "1.10.0"
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-ufotofu = "0.4.1"
+ufotofu = { version = "0.4.2", features = ["std"] }
 bytes = "1.6.0"
 syncify = "0.1.0"
 

--- a/data-model/Cargo.toml
+++ b/data-model/Cargo.toml
@@ -10,7 +10,7 @@ dev = ["dep:arbitrary"]
 [dependencies]
 either = "1.10.0"
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-ufotofu = "0.3.0"
+ufotofu = "0.4.1"
 bytes = "1.6.0"
 syncify = "0.1.0"
 

--- a/data-model/src/encoding/error.rs
+++ b/data-model/src/encoding/error.rs
@@ -1,6 +1,6 @@
-use core::error::Error;
 use core::{fmt::Display, fmt::Formatter, num::TryFromIntError};
 use either::Either;
+use std::error::Error;
 use ufotofu::common::errors::OverwriteFullSliceError;
 
 /// Everything that can go wrong when decoding a value.

--- a/data-model/src/encoding/relativity.rs
+++ b/data-model/src/encoding/relativity.rs
@@ -22,7 +22,7 @@ pub(super) mod encoding {
     #[syncify_replace(use crate::encoding::bytes::encoding_sync::produce_byte;)]
     use crate::encoding::bytes::encoding::produce_byte;
 
-    use core::mem::{size_of, MaybeUninit};
+    use core::mem::size_of;
 
     use crate::{
         encoding::{
@@ -121,12 +121,13 @@ pub(super) mod encoding {
             // Copy the raw path data of the prefix into the scratch buffer.
             unsafe {
                 // safe because we just copied the accumulated component lengths for the first `lcp_component_count` components.
-                MaybeUninit::copy_from_slice(
-                    buf.path_data_until_as_mut(lcp_component_count),
-                    &reference.raw_buf()[size_of::<usize>() * (reference.get_component_count() + 1)
-                        ..size_of::<usize>() * (reference.get_component_count() + 1)
-                            + prefix.get_path_length()],
-                );
+                buf.path_data_until_as_mut(lcp_component_count)
+                    .copy_from_slice(
+                        &reference.raw_buf()[size_of::<usize>()
+                            * (reference.get_component_count() + 1)
+                            ..size_of::<usize>() * (reference.get_component_count() + 1)
+                                + prefix.get_path_length()],
+                    );
             }
 
             let remaining_component_count: usize =
@@ -152,7 +153,7 @@ pub(super) mod encoding {
 
                 // Decode the component itself into the scratch buffer.
                 producer
-                    .bulk_overwrite_full_slice_uninit(unsafe {
+                    .bulk_overwrite_full_slice(unsafe {
                         // Safe because we called set_component_Accumulated_length for all j <= i
                         buf.path_data_as_mut(i)
                     })

--- a/data-model/src/lib.rs
+++ b/data-model/src/lib.rs
@@ -1,14 +1,5 @@
 //! Allo!
 
-#![feature(
-    new_uninit,
-    async_fn_traits,
-    debug_closure_helpers,
-    maybe_uninit_uninit_array,
-    maybe_uninit_write_slice,
-    maybe_uninit_slice
-)]
-
 pub mod encoding;
 mod entry;
 pub use entry::*;

--- a/data-model/src/path.rs
+++ b/data-model/src/path.rs
@@ -162,7 +162,7 @@ impl core::fmt::Display for InvalidPathError {
     }
 }
 
-impl core::error::Error for InvalidPathError {}
+impl std::error::Error for InvalidPathError {}
 
 /// An immutable Willow [path](https://willowprotocol.org/specs/data-model/index.html#Path). Thread-safe, cheap to clone, cheap to take prefixes of, expensive to append to.
 ///
@@ -846,7 +846,7 @@ mod encoding {
 
                 // Decode the component itself into the scratch buffer.
                 producer
-                    .bulk_overwrite_full_slice_uninit(unsafe {
+                    .bulk_overwrite_full_slice(unsafe {
                         // Safe because we called set_component_Accumulated_length for all j <= i
                         buf.path_data_as_mut(i)
                     })

--- a/earthstar/Cargo.toml
+++ b/earthstar/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 either = "1.10.0"
 willow-data-model = { path = "../data-model" }
 arbitrary = { version = "1.0.2", features = ["derive"]}
-ufotofu = "0.3.0"
+ufotofu = "0.4.1"
 
 [lints]
 workspace = true

--- a/earthstar/Cargo.toml
+++ b/earthstar/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 either = "1.10.0"
 willow-data-model = { path = "../data-model" }
 arbitrary = { version = "1.0.2", features = ["derive"]}
-ufotofu = "0.4.1"
+ufotofu = { version = "0.4.2", features = ["std"] }
 
 [lints]
 workspace = true

--- a/earthstar/src/cinn25519.rs
+++ b/earthstar/src/cinn25519.rs
@@ -136,10 +136,10 @@ impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> Decodable
         Producer: BulkProducer<Item = u8>,
     {
         if MIN_LENGTH == MAX_LENGTH {
-            let mut shortname_box = Box::new_uninit_slice(MIN_LENGTH);
+            let mut shortname_box = vec![0; MIN_LENGTH].into_boxed_slice();
 
-            let shortname_bytes = producer
-                .bulk_overwrite_full_slice_uninit(shortname_box.as_mut())
+            producer
+                .bulk_overwrite_full_slice(shortname_box.as_mut())
                 .await?;
 
             let mut underlying_slice = [0u8; 32];
@@ -149,7 +149,7 @@ impl<const MIN_LENGTH: usize, const MAX_LENGTH: usize> Decodable
                 .await?;
 
             return Ok(Self {
-                shortname: Shortname(shortname_bytes.to_vec()),
+                shortname: Shortname(shortname_box.into()),
                 underlying: underlying_slice,
             });
         }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 workspace = true
 
 [dependencies]
-ufotofu = { version = "0.3.0", features=["dev"]}
+ufotofu = { version = "0.4.1", features=["dev"]}
 smol = "2.0.0"
 arbitrary = { version = "1.0.2", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 workspace = true
 
 [dependencies]
-ufotofu = { version = "0.4.1", features=["dev"]}
+ufotofu = { version = "0.4.2", features = ["std", "dev"] }
 smol = "2.0.0"
 arbitrary = { version = "1.0.2", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }

--- a/fuzz/src/encode.rs
+++ b/fuzz/src/encode.rs
@@ -26,7 +26,7 @@ where
 
     let mut new_vec = Vec::new();
 
-    new_vec.extend_from_slice(consumer.as_ref());
+    new_vec.extend_from_slice(consumer.consumed());
 
     // THis should eventually be a testproducer, when we are able to initialise one with some known data.
     let mut producer = FromBoxedSlice::from_vec(new_vec);
@@ -53,7 +53,7 @@ where
 
             item.encode(&mut consumer).await.unwrap();
 
-            let encoded = consumer.as_ref().as_slice();
+            let encoded = consumer.as_ref();
 
             assert_eq!(encoded, &data[0..producer.get_offset()]);
         }
@@ -133,7 +133,7 @@ pub async fn relative_encoding_roundtrip<T, R, C>(
 
     let mut new_vec = Vec::new();
 
-    new_vec.extend_from_slice(consumer.as_ref());
+    new_vec.extend_from_slice(consumer.consumed());
 
     // THis should eventually be a testproducer, when we are able to initialise one with some known data.
     let mut producer = FromBoxedSlice::from_vec(new_vec);
@@ -164,7 +164,7 @@ where
                 .await
                 .unwrap();
 
-            let encoded = consumer.as_ref().as_slice();
+            let encoded = consumer.as_ref();
 
             assert_eq!(encoded, &data[0..producer.get_offset()]);
         }

--- a/meadowcap/Cargo.toml
+++ b/meadowcap/Cargo.toml
@@ -9,7 +9,7 @@ dev = ["dep:arbitrary"]
 
 [dependencies]
 signature = "2.2.0"
-ufotofu = "0.4.1"
+ufotofu = { version = "0.4.2", features = ["std"] }
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
 either = "1.13.0"
 syncify = "0.1.0"

--- a/meadowcap/Cargo.toml
+++ b/meadowcap/Cargo.toml
@@ -9,7 +9,7 @@ dev = ["dep:arbitrary"]
 
 [dependencies]
 signature = "2.2.0"
-ufotofu = "0.3.0"
+ufotofu = "0.4.1"
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
 either = "1.13.0"
 syncify = "0.1.0"


### PR DESCRIPTION
- Removes usage of `MaybeUnit` in path, 
- use `std::error::Error` instead of `core::error::Error`
- No longer use `uninit` flavoured ufotofu APIs