### PR TITLE
refactor: changes done while porting iroh-willow

### DIFF
--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -13,7 +13,7 @@ pub type Timestamp = u64;
 
 /// The metadata associated with each Payload.
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#Entry).
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Ord, PartialOrd)]
 pub struct Entry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>
 where
     N: NamespaceId,

--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -13,7 +13,7 @@ pub type Timestamp = u64;
 
 /// The metadata associated with each Payload.
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#Entry).
-#[derive(Debug, PartialEq, Eq, Clone, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Clone, Ord, PartialOrd, Hash)]
 pub struct Entry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>
 where
     N: NamespaceId,

--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -13,6 +13,9 @@ pub type Timestamp = u64;
 
 /// The metadata associated with each Payload.
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#Entry).
+///
+/// [`Entry`] implements `Ord` and `PartialOrd`, and sorts by namespace id first, then subspace id,
+/// then path, then timestamp, then payload digest, and then payload length.
 #[derive(Debug, PartialEq, Eq, Clone, Ord, PartialOrd, Hash)]
 pub struct Entry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>
 where
@@ -28,10 +31,10 @@ where
     path: Path<MCL, MCC, MPL>,
     /// The claimed creation time of the [`Entry`].
     timestamp: Timestamp,
-    /// The length of the Payload in bytes.
-    payload_length: u64,
     /// The result of applying hash_payload to the Payload.
     payload_digest: PD,
+    /// The length of the Payload in bytes.
+    payload_length: u64,
 }
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD> Entry<MCL, MCC, MPL, N, S, PD>

--- a/data-model/src/entry.rs
+++ b/data-model/src/entry.rs
@@ -230,8 +230,8 @@ impl std::error::Error for UnauthorisedWriteError {}
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#AuthorisedEntry).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AuthorisedEntry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>(
-    pub Entry<MCL, MCC, MPL, N, S, PD>,
-    pub AT,
+    Entry<MCL, MCC, MPL, N, S, PD>,
+    AT,
 )
 where
     N: NamespaceId,
@@ -259,6 +259,35 @@ where
         }
 
         Err(UnauthorisedWriteError)
+    }
+
+    /// Construct an [`AuthorisedEntry`] without checking if the token permits the writing of this
+    /// entry.
+    ///
+    /// Should only be used if the token was created by ourselves or previously validated.
+    pub fn new_unchecked(
+        entry: Entry<MCL, MCC, MPL, N, S, PD>,
+        token: AT,
+    ) -> Self
+    where
+        AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
+    {
+        Self(entry, token)
+    }
+
+    /// Split into [`Entry`] and [`AuthorisationToken`] halves.
+    pub fn into_parts(self) -> (Entry<MCL, MCC, MPL, N, S, PD>, AT) {
+        (self.0, self.1)
+    }
+
+    /// Get a reference to the [`Entry`].
+    pub fn entry(&self) -> &Entry<MCL, MCC, MPL, N, S, PD> {
+        &self.0
+    }
+
+    /// Get a reference to the [`AuthorisationToken`].
+    pub fn token(&self) -> &AT {
+        &self.1
     }
 }
 

--- a/data-model/src/grouping/area_of_interest.rs
+++ b/data-model/src/grouping/area_of_interest.rs
@@ -18,7 +18,11 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
 {
     /// Creates a new [`AreaOfInterest`].
     pub fn new(area: Area<MCL, MCC, MPL, S>, max_count: u64, max_size: u64) -> Self {
-        Self { area, max_count, max_size }
+        Self {
+            area,
+            max_count,
+            max_size,
+        }
     }
 
     /// Return the intersection of this [`AreaOfInterest`] with another.

--- a/data-model/src/grouping/area_of_interest.rs
+++ b/data-model/src/grouping/area_of_interest.rs
@@ -16,11 +16,16 @@ pub struct AreaOfInterest<const MCL: usize, const MCC: usize, const MPL: usize, 
 impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
     AreaOfInterest<MCL, MCC, MPL, S>
 {
+    /// Creates a new [`AreaOfInterest`].
+    pub fn new(area: Area<MCL, MCC, MPL, S>, max_count: u64, max_size: u64) -> Self {
+        Self { area, max_count, max_size }
+    }
+
     /// Return the intersection of this [`AreaOfInterest`] with another.
     /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#aoi_intersection).
     pub fn intersection(
         &self,
-        other: AreaOfInterest<MCL, MCC, MPL, S>,
+        other: &AreaOfInterest<MCL, MCC, MPL, S>,
     ) -> Option<AreaOfInterest<MCL, MCC, MPL, S>> {
         match self.area.intersection(&other.area) {
             None => None,

--- a/data-model/src/grouping/range.rs
+++ b/data-model/src/grouping/range.rs
@@ -6,7 +6,7 @@ use arbitrary::{Arbitrary, Error as ArbitraryError};
 
 use crate::path::Path;
 
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 /// Determines whether a [`Range`] is _closed_ or _open_.
 pub enum RangeEnd<T: Ord> {
     /// A [closed range](https://willowprotocol.org/specs/grouping-entries/index.html#closed_range) consists of a [start value](https://willowprotocol.org/specs/grouping-entries/index.html#start_value) and an [end_value](https://willowprotocol.org/specs/grouping-entries/index.html#end_value).
@@ -119,18 +119,6 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> PartialOrd<RangeEnd<P
     }
 }
 
-impl<T> Clone for RangeEnd<T>
-where
-    T: Ord + Clone,
-{
-    fn clone(&self) -> Self {
-        match self {
-            RangeEnd::Closed(val) => RangeEnd::Closed(val.clone()),
-            RangeEnd::Open => RangeEnd::Open,
-        }
-    }
-}
-
 #[cfg(feature = "dev")]
 impl<'a, T> Arbitrary<'a> for RangeEnd<T>
 where
@@ -152,7 +140,7 @@ where
 /// One-dimensional grouping over a type of value.
 ///
 /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#range)
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct Range<T: Ord> {
     /// A range [includes](https://willowprotocol.org/specs/grouping-entries/index.html#range_include) all values greater than or equal to its [start value](https://willowprotocol.org/specs/grouping-entries/index.html#start_value) **and** less than its [end_value](https://willowprotocol.org/specs/grouping-entries/index.html#end_value)
     pub start: T,
@@ -164,6 +152,11 @@ impl<T> Range<T>
 where
     T: Ord + Clone,
 {
+    /// Construct a range.
+    pub fn new(start: T, end: RangeEnd<T>) -> Self {
+        Self { start, end }
+    }
+
     /// Construct a new [open range](https://willowprotocol.org/specs/grouping-entries/index.html#open_range) from a [start value](https://willowprotocol.org/specs/grouping-entries/index.html#start_value).
     pub fn new_open(start: T) -> Self {
         Self {
@@ -245,18 +238,6 @@ impl<T: Ord> Ord for Range<T> {
 impl<T: Ord> PartialOrd for Range<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl<T> Clone for Range<T>
-where
-    T: Ord + Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            start: self.start.clone(),
-            end: self.end.clone(),
-        }
     }
 }
 

--- a/data-model/src/grouping/range_3d.rs
+++ b/data-model/src/grouping/range_3d.rs
@@ -41,7 +41,11 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
 
     /// Create a new [`Range3d`] that covers everything.
     pub fn new_full() -> Self {
-        Self::new(Default::default(), Range::new_open(Path::new_empty()), Default::default())
+        Self::new(
+            Default::default(),
+            Range::new_open(Path::new_empty()),
+            Default::default(),
+        )
     }
 
     /// Return a reference to the range of [`SubspaceId`]s.

--- a/data-model/src/grouping/range_3d.rs
+++ b/data-model/src/grouping/range_3d.rs
@@ -39,6 +39,11 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
         }
     }
 
+    /// Create a new [`Range3d`] that covers everything.
+    pub fn new_full() -> Self {
+        Self::new(Default::default(), Range::new_open(Path::new_empty()), Default::default())
+    }
+
     /// Return a reference to the range of [`SubspaceId`]s.
     /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#SubspaceRange).
     pub fn subspaces(&self) -> &Range<S> {

--- a/fuzz/fuzz_targets/mc_is_authorised_write.rs
+++ b/fuzz/fuzz_targets/mc_is_authorised_write.rs
@@ -19,7 +19,7 @@ fuzz_target!(|data: (
     let (entry, token) = data;
 
     let is_within_granted_area = token.capability.granted_area().includes_entry(&entry);
-    let is_write_cap = token.capability.access_mode() == &AccessMode::Write;
+    let is_write_cap = token.capability.access_mode() == AccessMode::Write;
 
     let mut consumer = IntoVec::<u8>::new();
     entry.encode(&mut consumer).unwrap();

--- a/meadowcap/src/communal_capability.rs
+++ b/meadowcap/src/communal_capability.rs
@@ -26,7 +26,7 @@ impl<NamespacePublicKey: std::fmt::Debug> std::error::Error
 /// A capability that implements [communal namespaces](https://willowprotocol.org/specs/meadowcap/index.html#communal_namespace).
 ///
 /// [Definition](https://willowprotocol.org/specs/meadowcap/index.html#communal_capabilities).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CommunalCapability<
     const MCL: usize,
     const MCC: usize,
@@ -157,8 +157,8 @@ where
     /// The kind of access this capability grants.
     ///
     /// [Definition](https://willowprotocol.org/specs/meadowcap/index.html#communal_cap_mode)
-    pub fn access_mode(&self) -> &AccessMode {
-        &self.access_mode
+    pub fn access_mode(&self) -> AccessMode {
+        self.access_mode
     }
 
     /// The user to whom this capability grants access.

--- a/meadowcap/src/lib.rs
+++ b/meadowcap/src/lib.rs
@@ -28,7 +28,7 @@ pub trait IsCommunal {
 }
 
 /// A delegation of access rights to a user for a given [area](https://willowprotocol.org/specs/grouping-entries/index.html#areas).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Delegation<
     const MCL: usize,
     const MCC: usize,
@@ -100,7 +100,7 @@ where
 }
 
 /// A mode granting read or write access to some [`Area`].
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AccessMode {
     Read,
     Write,

--- a/meadowcap/src/mc_authorisation_token.rs
+++ b/meadowcap/src/mc_authorisation_token.rs
@@ -45,6 +45,49 @@ impl<
         NamespaceSignature,
         UserPublicKey,
         UserSignature,
+    >
+    McAuthorisationToken<
+        MCL,
+        MCC,
+        MPL,
+        NamespacePublicKey,
+        NamespaceSignature,
+        UserPublicKey,
+        UserSignature,
+    >
+where
+    NamespacePublicKey: NamespaceId + Encodable + Verifier<NamespaceSignature> + IsCommunal,
+    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
+    NamespaceSignature: Encodable + Clone,
+    UserSignature: Encodable + Clone,
+{
+    pub fn new(
+        capability: McCapability<
+            MCL,
+            MCC,
+            MPL,
+            NamespacePublicKey,
+            NamespaceSignature,
+            UserPublicKey,
+            UserSignature,
+        >,
+        signature: UserSignature,
+    ) -> Self {
+        Self {
+            capability,
+            signature,
+        }
+    }
+}
+
+impl<
+        const MCL: usize,
+        const MCC: usize,
+        const MPL: usize,
+        NamespacePublicKey,
+        NamespaceSignature,
+        UserPublicKey,
+        UserSignature,
         PD,
     > AuthorisationToken<MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, PD>
     for McAuthorisationToken<

--- a/meadowcap/src/mc_subspace_capability.rs
+++ b/meadowcap/src/mc_subspace_capability.rs
@@ -10,7 +10,7 @@ use crate::IsCommunal;
 use arbitrary::{Arbitrary, Error as ArbitraryError};
 
 /// A [delegation](https://willowprotocol.org/specs/pai/index.html#subspace_cap_delegations) of read access for arbitrary `SubspaceId`s to a `UserPublicKey`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "dev", derive(Arbitrary))]
 pub struct SubspaceDelegation<UserPublicKey, UserSignature>
 where
@@ -42,7 +42,7 @@ where
 /// A capability that certifies read access to arbitrary [SubspaceIds](https://willowprotocol.org/specs/data-model/index.html#SubspaceId) at some unspecified non-empty [`willow_data_model::Path`].
 ///
 /// [Definition](https://willowprotocol.org/specs/pai/index.html#subspace_capability)
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct McSubspaceCapability<
     NamespacePublicKey,
     NamespaceSignature,
@@ -69,9 +69,9 @@ where
     UserSignature: Encodable + Clone,
 {
     /// Generate a new [`McSubspaceCapability`] for a given user, or return an error if the given namespace secret is incorrect.
-    pub fn new<const MCL: usize, const MCC: usize, const MPL: usize, NamespaceSecret>(
+    pub fn new<NamespaceSecret>(
         namespace_key: NamespacePublicKey,
-        namespace_secret: NamespaceSecret,
+        namespace_secret: &NamespaceSecret,
         user_key: UserPublicKey,
     ) -> Result<
         McSubspaceCapability<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>,

--- a/meadowcap/src/owned_capability.rs
+++ b/meadowcap/src/owned_capability.rs
@@ -40,7 +40,7 @@ impl<NamespacePublicKey: std::fmt::Debug> std::error::Error
 /// A capability that implements [owned namespaces](https://willowprotocol.org/specs/meadowcap/index.html#owned_namespace).
 ///
 /// [Definition](https://willowprotocol.org/specs/meadowcap/index.html#owned_capabilities).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OwnedCapability<
     const MCL: usize,
     const MCC: usize,
@@ -89,7 +89,7 @@ where
     /// Create a new owned capability granting access to the [full area](https://willowprotocol.org/specs/grouping-entries/index.html#full_area) of the [namespace](https://willowprotocol.org/specs/data-model/index.html#namespace) to the given `UserPublicKey`.
     pub fn new<NamespaceSecret>(
         namespace_key: NamespacePublicKey,
-        namespace_secret: NamespaceSecret,
+        namespace_secret: &NamespaceSecret,
         user_key: UserPublicKey,
         access_mode: AccessMode,
     ) -> Result<Self, OwnedCapabilityCreationError<NamespacePublicKey>>
@@ -263,8 +263,8 @@ where
     /// The kind of access this capability grants.
     ///
     /// [Definition](https://willowprotocol.org/specs/meadowcap/index.html#owned_cap_mode)
-    pub fn access_mode(&self) -> &AccessMode {
-        &self.access_mode
+    pub fn access_mode(&self) -> AccessMode {
+        self.access_mode
     }
 
     /// The user to whom this capability grants access.


### PR DESCRIPTION
This PR contains changes I made to willow-rs while porting iroh-willow to use willow-rs.

The changes are mostly small and not all related to each other. They were mostly done by doing jump to definition from iroh-willow when touching willow-rs parts that didn't fit in well yet.

I will add review comments in the diff to explain the motivation.

My idea was to submit this here, let you review it, and if anything warrants further discussion, I will separate it out into its own PR, to keep only uncontroversial things in here that can easily be merged.

If you prefer to split this up right away, let me know.