### PR TITLE
chore/fix: add CI for more platforms and targets, fix build error on 32bit systems

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build_and_test_nix:
     timeout-minutes: 30
-    name: "Build and test (Linux and macOS)"
+    name: "Build and test (nix)"
     strategy:
       fail-fast: false
       matrix:
@@ -192,7 +192,7 @@ jobs:
         # cargo ndk --target ${{ matrix.target }} test --workspace --exclude willow-fuzz --exclude earthstar
 
   cross_build_and_test:
-    name: Cross-compile build and test
+    name: Cross build and test
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -196,39 +196,35 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         target:
           - i686-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
           # note that there are known bugs in arm cross-compile qemu runners
           # if issues appear we might have to disable these
           # - see https://github.com/cross-rs/cross/issues/1311
-          - armv7-linux-androideabi
-          - aarch64-linux-android
+          - armv7-linux-androideabi@23
+          - aarch64-linux-android@23
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Install rust stable
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Cleanup Docker
-      continue-on-error: true
-      run: |
-        docker kill $(docker ps -q)
-
-      # See https://github.com/cross-rs/cross/issues/1222
-    - uses: taiki-e/install-action@cross
-
-    - name: build
-      run: cross build --all --target ${{ matrix.target }} --workspace --exclude willow-fuzz
-
-    - name: test
-      run: cross test --all --target ${{ matrix.target }} --workspace --exclude willow-fuzz -- --test-threads=12
-      env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - name: Cleanup Docker
+        continue-on-error: true
+        run: |
+          docker kill $(docker ps -q)
+      
+      # setup-cross-toolchain-action sets the `CARGO_BUILD_TARGET` environment variable,
+      # so there is no need for an explicit `--target` flag.
+      - name: Build tests
+        run: cargo build --workspace --exclude willow-fuzz
+      - name: Run tests
+        run: cargo test --verbose --workspace --exclude willow-fuzz
 
   fuzz_tests:
     timeout-minutes: 30

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
         rust: [stable]
-        features: [all, none, default]
+        # once feature flags are used more, enable testing with all combinations
+        # features: [all, none, default]
+        features: [none, default]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -78,7 +80,9 @@ jobs:
       matrix:
         os: [windows-latest]
         rust: [stable]
-        features: [all, none, default]
+        # once feature flags are used more, enable testing with all combinations
+        # features: [all, none, default]
+        features: [default]
         target:
           - x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
@@ -180,10 +184,11 @@ jobs:
     - name: Build
       env:
         ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
         cargo install cargo-ndk
         cargo ndk --target ${{ matrix.target }} build
-        cargo ndk --target ${{ matrix.target }} test --workspace --exclude willow-fuzz
+        cargo ndk --target ${{ matrix.target }} test --workspace --exclude willow-fuzz --exclude earthstar
 
   cross_build_and_test:
     name: Cross-compile build and test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,15 +8,262 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
+  MSRV: "1.76"
 
 jobs:
-  build:
+  build_and_test_nix:
+    timeout-minutes: 30
+    name: "Build and test (Linux and macOS)"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        rust: [stable]
+        features: [all, none, default]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install ${{ matrix.rust }} rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
 
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
+
+    - name: Select features
+      run: |
+        case "${{ matrix.features }}" in
+            all)
+                echo "FEATURES=--all-features" >> "$GITHUB_ENV"
+                ;;
+            none)
+                echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
+                ;;
+            default)
+                echo "FEATURES=" >> "$GITHUB_ENV"
+                ;;
+            *)
+                exit 1
+        esac
+
+    - name: build tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+
+    - name: run tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-fail-fast
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+
+    - name: run doctests
+      if: ${{ matrix.features == 'all' }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+      run: |
+        cargo test --workspace --all-features --doc
+
+  build_and_test_windows:
+    timeout-minutes: 30
+    name: "Build and test (Windows)"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        rust: [stable]
+        features: [all, none, default]
+        target:
+          - x86_64-pc-windows-msvc
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.git-ref }}
+
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
+
+    - name: Install cargo-nextest
+      shell: powershell
+      run: |
+        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+        $tmp | Expand-Archive -DestinationPath $outputDir -Force
+        $tmp | Remove-Item
+
+    - name: Select features
+      run: |
+        switch ("${{ matrix.features }}") {
+            "all" {
+                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "none" {
+                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "default" {
+                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            default {
+                Exit 1
+            }
+        }
+
+    - uses: msys2/setup-msys2@v2
+
+    - name: build tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+
+    - name: run tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-fail-fast
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+
+    - name: run doctests
+      if: ${{ matrix.features == 'all' }}
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+      run: |
+        cargo test --workspace --all-features --doc
+
+  android_build_and_test:
+    name: "Build and test (Android)"
+    timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-linux-android
+          - armv7-linux-androideabi
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        target: ${{ matrix.target }}
+    - name: Install rustup target
+      run: rustup target add ${{ matrix.target }}
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Setup Android NDK
+      uses: arqu/setup-ndk@main
+      id: setup-ndk
+      with:
+        ndk-version: r23
+        add-to-path: true
+
+    - name: Build
+      env:
+        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+      run: |
+        cargo install cargo-ndk
+        cargo ndk --target ${{ matrix.target }} build
+        cargo ndk --target ${{ matrix.target }} test
+
+  cross_build_and_test:
+    name: Cross-compile build and test
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - i686-unknown-linux-gnu
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install rust stable
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cleanup Docker
+      continue-on-error: true
+      run: |
+        docker kill $(docker ps -q)
+
+      # See https://github.com/cross-rs/cross/issues/1222
+    - uses: taiki-e/install-action@cross
+
+    - name: build
+      run: cross build --all --target ${{ matrix.target }}
+
+    - name: test
+      run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
+
+  check_fmt:
+    timeout-minutes: 30
+    name: Checking fmt
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+
+    - name: fmt
+      run: cargo fmt --all -- --check
+
+  check_docs:
+    timeout-minutes: 30
+    name: Checking docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2024-05-02
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.5
+
+    - name: Docs
+      run: cargo doc --workspace --all-features --no-deps --document-private-items
+      env:
+        RUSTDOCFLAGS: --cfg docsrs
+
+  clippy_check:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.5
+
+    - name: clippy check (all features)
+      run: cargo clippy --workspace --all-features --all-targets --bins --tests --benches
+
+    - name: clippy check (no features)
+      run: cargo clippy --workspace --no-default-features --lib --bins --tests
+
+    - name: clippy check (default features)
+      run: cargo clippy --workspace --all-targets

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -223,7 +223,7 @@ jobs:
     - uses: taiki-e/install-action@cross
 
     - name: build
-      run: cross build --all --target ${{ matrix.target }} --workspace
+      run: cross build --all --target ${{ matrix.target }} --workspace --exclude willow-fuzz
 
     - name: test
       run: cross test --all --target ${{ matrix.target }} --workspace --exclude willow-fuzz -- --test-threads=12

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         rust: [stable]
         features: [all, none, default]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -80,6 +81,7 @@ jobs:
         features: [all, none, default]
         target:
           - x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -200,6 +200,11 @@ jobs:
       matrix:
         target:
           - i686-unknown-linux-gnu
+          # note that there are known bugs in arm cross-compile qemu runners
+          # if issues appear we might have to disable these
+          # - see https://github.com/cross-rs/cross/issues/1311
+          - armv7-linux-androideabi
+          - aarch64-linux-android
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -144,8 +144,8 @@ jobs:
       run: |
         cargo test --workspace --exclude willow-fuzz --all-features --doc
 
-  android_build_and_test:
-    name: "Build and test (Android)"
+  android_build:
+    name: "Build only (Android)"
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
@@ -188,7 +188,8 @@ jobs:
       run: |
         cargo install cargo-ndk
         cargo ndk --target ${{ matrix.target }} build
-        cargo ndk --target ${{ matrix.target }} test --workspace --exclude willow-fuzz --exclude earthstar
+        # TODO: would be good to actually run tests on android, but this is not working at the moment.
+        # cargo ndk --target ${{ matrix.target }} test --workspace --exclude willow-fuzz --exclude earthstar
 
   cross_build_and_test:
     name: Cross-compile build and test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,7 +215,7 @@ jobs:
       run: cross build --all --target ${{ matrix.target }} --workspace
 
     - name: test
-      run: cross test --all --target ${{ matrix.target }} --workspace --exclude willow-fuzz-- --test-threads=12
+      run: cross test --all --target ${{ matrix.target }} --workspace --exclude willow-fuzz -- --test-threads=12
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build_and_test_nix:
     timeout-minutes: 30
-    name: "Build and test (nix)"
+    name: "Build and test"
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +82,7 @@ jobs:
         rust: [stable]
         # once feature flags are used more, enable testing with all combinations
         # features: [all, none, default]
-        features: [default]
+        features: [default, none]
         target:
           - x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
@@ -144,55 +144,8 @@ jobs:
       run: |
         cargo test --workspace --exclude willow-fuzz --all-features --doc
 
-  android_build:
-    name: "Build only (Android)"
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - aarch64-linux-android
-          - armv7-linux-androideabi
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        target: ${{ matrix.target }}
-    - name: Install rustup target
-      run: rustup target add ${{ matrix.target }}
-
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-
-    - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
-
-    - name: Setup Android NDK
-      uses: arqu/setup-ndk@main
-      id: setup-ndk
-      with:
-        ndk-version: r23
-        add-to-path: true
-
-    - name: Build
-      env:
-        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-        ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
-      run: |
-        cargo install cargo-ndk
-        cargo ndk --target ${{ matrix.target }} build
-        # TODO: would be good to actually run tests on android, but this is not working at the moment.
-        # cargo ndk --target ${{ matrix.target }} test --workspace --exclude willow-fuzz --exclude earthstar
-
   cross_build_and_test:
-    name: Cross build and test
+    name: Build and test (cross)
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
@@ -205,6 +158,16 @@ jobs:
           # - see https://github.com/cross-rs/cross/issues/1311
           - armv7-linux-androideabi@23
           - aarch64-linux-android@23
+        include:
+          - target: i686-unknown-linux-gnu
+            name: Linux 32bit
+          - target: aarch64-unknown-linux-gnu
+            name: Linux aarch64
+          - target: armv7-linux-androideabi@23
+            name: Android armv7
+          - target: aarch64-linux-android@23
+            name: Android aarch64
+          
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -249,7 +212,7 @@ jobs:
 
   check_fmt:
     timeout-minutes: 30
-    name: Checking fmt
+    name: Chec fmt
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -263,7 +226,7 @@ jobs:
 
   check_docs:
     timeout-minutes: 30
-    name: Checking docs
+    name: Check docs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -279,6 +242,7 @@ jobs:
         RUSTDOCFLAGS: --cfg docsrs
 
   clippy_check:
+    name: Check clippy
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,11 +55,11 @@ jobs:
 
     - name: build tests
       run: |
-        cargo nextest run --exclude willow-fuzz --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+        cargo nextest run --workspace --exclude willow-fuzz ${{ env.FEATURES }} --lib --bins --tests --no-run
 
     - name: run tests
       run: |
-        cargo nextest run --exclude willow-fuzz --workspace ${{ env.FEATURES }} --lib --bins --tests --no-fail-fast
+        cargo nextest run --workspace --exclude willow-fuzz ${{ env.FEATURES }} --lib --bins --tests --no-fail-fast
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
@@ -183,7 +183,7 @@ jobs:
       run: |
         cargo install cargo-ndk
         cargo ndk --target ${{ matrix.target }} build
-        cargo ndk --target ${{ matrix.target }} test --exclude willow-fuzz
+        cargo ndk --target ${{ matrix.target }} test --workspace --exclude willow-fuzz
 
   cross_build_and_test:
     name: Cross-compile build and test
@@ -212,10 +212,10 @@ jobs:
     - uses: taiki-e/install-action@cross
 
     - name: build
-      run: cross build --all --target ${{ matrix.target }}
+      run: cross build --all --target ${{ matrix.target }} --workspace
 
     - name: test
-      run: cross test --all --target ${{ matrix.target }} --exclude willow-fuzz-- --test-threads=12
+      run: cross test --all --target ${{ matrix.target }} --workspace --exclude willow-fuzz-- --test-threads=12
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,11 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
 
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
+
     - name: Select features
       run: |
         case "${{ matrix.features }}" in
@@ -50,11 +55,11 @@ jobs:
 
     - name: build tests
       run: |
-        cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+        cargo nextest run --exclude willow-fuzz --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
 
     - name: run tests
       run: |
-        cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests
+        cargo nextest run --exclude willow-fuzz --workspace ${{ env.FEATURES }} --lib --bins --tests --no-fail-fast
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
@@ -63,7 +68,7 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
       run: |
-        cargo test --workspace --all-features --doc
+        cargo test --workspace --exclude willow-fuzz --all-features --doc
 
   build_and_test_windows:
     timeout-minutes: 30
@@ -90,6 +95,15 @@ jobs:
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
 
+    - name: Install cargo-nextest
+      shell: powershell
+      run: |
+        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+        $tmp | Expand-Archive -DestinationPath $outputDir -Force
+        $tmp | Remove-Item
+
     - name: Select features
       run: |
         switch ("${{ matrix.features }}") {
@@ -111,11 +125,11 @@ jobs:
 
     - name: build tests
       run: |
-        cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+        cargo nextest run --workspace --exclude willow-fuzz ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
 
     - name: run tests
       run: |
-        cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
+        cargo nextest run --workspace --exclude willow-fuzz ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-fail-fast
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
@@ -124,7 +138,7 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
       run: |
-        cargo test --workspace --all-features --doc
+        cargo test --workspace --exclude willow-fuzz --all-features --doc
 
   android_build_and_test:
     name: "Build and test (Android)"
@@ -169,7 +183,7 @@ jobs:
       run: |
         cargo install cargo-ndk
         cargo ndk --target ${{ matrix.target }} build
-        cargo ndk --target ${{ matrix.target }} test
+        cargo ndk --target ${{ matrix.target }} test --exclude willow-fuzz
 
   cross_build_and_test:
     name: Cross-compile build and test
@@ -201,9 +215,30 @@ jobs:
       run: cross build --all --target ${{ matrix.target }}
 
     - name: test
-      run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
+      run: cross test --all --target ${{ matrix.target }} --exclude willow-fuzz-- --test-threads=12
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
+
+  fuzz_tests:
+    timeout-minutes: 30
+    name: "Run fuzz tests"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust: [nightly]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install ${{ matrix.rust }} rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+
+    - name: build and run fuzz tests
+      run: |
+        cargo test -p willow-fuzz
 
   check_fmt:
     timeout-minutes: 30

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,11 +32,6 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
 
-    - name: Install cargo-nextest
-      uses: taiki-e/install-action@v2
-      with:
-        tool: nextest
-
     - name: Select features
       run: |
         case "${{ matrix.features }}" in
@@ -55,11 +50,11 @@ jobs:
 
     - name: build tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+        cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
 
     - name: run tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-fail-fast
+        cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
@@ -95,15 +90,6 @@ jobs:
         rustup target add ${{ matrix.target }}
         rustup set default-host ${{ matrix.target }}
 
-    - name: Install cargo-nextest
-      shell: powershell
-      run: |
-        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-        $tmp | Expand-Archive -DestinationPath $outputDir -Force
-        $tmp | Remove-Item
-
     - name: Select features
       run: |
         switch ("${{ matrix.features }}") {
@@ -125,11 +111,11 @@ jobs:
 
     - name: build tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+        cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
 
     - name: run tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-fail-fast
+        cargo test --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }}
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 

--- a/data-model/src/relative_encodings.rs
+++ b/data-model/src/relative_encodings.rs
@@ -1,9 +1,10 @@
 use syncify::syncify;
-use syncify::syncify_replace;
 
 #[syncify(encoding_sync)]
 pub(super) mod encoding {
-    use super::*;
+    // TODO: Unclear why this is marked unused.
+    #[allow(unused_imports)]
+    use syncify::syncify_replace;
 
     #[syncify_replace(use ufotofu::sync::{BulkConsumer, BulkProducer};)]
     use ufotofu::local_nb::{BulkConsumer, BulkProducer};

--- a/earthstar/src/lib.rs
+++ b/earthstar/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(new_uninit)]
-
 pub mod cinn25519;
 pub mod identity_id;
 pub mod namespace_id;

--- a/encoding/src/bytes.rs
+++ b/encoding/src/bytes.rs
@@ -2,13 +2,14 @@ use syncify::syncify;
 
 #[syncify(encoding_sync)]
 pub mod encoding {
-
     use crate::error::DecodeError;
-
     use either::Either;
+    // TODO: Somehow this is marked as unused. But if I remove it, the syncify_replace is not
+    // working. Weird!
+    #[allow(unused_imports)]
     use syncify::syncify_replace;
 
-    #[syncify_replace(use ufotofu::sync::{ BulkProducer};)]
+    #[syncify_replace(use ufotofu::sync::BulkProducer;)]
     use ufotofu::local_nb::BulkProducer;
 
     /// Have `Producer` produce a single byte, or return an error if the final value was produced or the producer experienced an error.

--- a/encoding/src/max_power.rs
+++ b/encoding/src/max_power.rs
@@ -4,20 +4,20 @@ use syncify::syncify_replace;
 /// Return the least natural number such that 256^`n` is greater than or equal to `n`.
 ///
 /// Used for determining the minimal number of bytes needed to represent a given unsigned integer, and more specifically [`path_length_power`](https://willowprotocol.org/specs/encodings/index.html#path_length_power) and [`path_count_power`](https://willowprotocol.org/specs/encodings/index.html#path_count_power).
-pub const fn max_power(max_size: usize) -> u8 {
+pub const fn max_power(max_size: u64) -> u8 {
     if max_size < 256 {
         1
-    } else if max_size < 65536 {
+    } else if max_size < 256u64.pow(2) {
         2
-    } else if max_size < 16777216 {
+    } else if max_size < 256u64.pow(3) {
         3
-    } else if max_size < 4294967296 {
+    } else if max_size < 256u64.pow(4) {
         4
-    } else if max_size < (256_usize).pow(5) {
+    } else if max_size < 256u64.pow(5) {
         5
-    } else if max_size < (256_usize).pow(6) {
+    } else if max_size < 256u64.pow(6) {
         6
-    } else if max_size < (256_usize).pow(7) {
+    } else if max_size < 256u64.pow(7) {
         7
     } else {
         8
@@ -48,7 +48,7 @@ pub(super) mod encoding {
             panic!("Can't encode a value larger than its maximum possible value!")
         }
 
-        let power = max_power(max_size);
+        let power = max_power(max_size as u64);
         let value_encoded_raw: [u8; size_of::<u64>()] = (value as u64).to_be_bytes();
 
         consumer
@@ -67,7 +67,7 @@ pub(super) mod encoding {
     where
         P: BulkProducer<Item = u8>,
     {
-        let power = max_power(max_size);
+        let power = max_power(max_size as u64);
         let mut slice = [0u8; size_of::<u64>()];
 
         producer

--- a/encoding/src/max_power.rs
+++ b/encoding/src/max_power.rs
@@ -49,7 +49,7 @@ pub(super) mod encoding {
         }
 
         let power = max_power(max_size);
-        let value_encoded_raw: [u8; size_of::<u64>()] = value.to_be_bytes();
+        let value_encoded_raw: [u8; size_of::<u64>()] = (value as u64).to_be_bytes();
 
         consumer
             .bulk_consume_full_slice(&value_encoded_raw[size_of::<u64>() - (power as usize)..])

--- a/meadowcap/src/mc_capability.rs
+++ b/meadowcap/src/mc_capability.rs
@@ -367,7 +367,7 @@ pub(super) mod encoding {
                 }
             }
 
-            let delegations_count = self.delegations_len();
+            let delegations_count = self.delegations_len() as u64;
 
             if delegations_count >= 4294967296 {
                 header |= 0b0011_1111;

--- a/meadowcap/src/mc_capability.rs
+++ b/meadowcap/src/mc_capability.rs
@@ -394,7 +394,7 @@ pub(super) mod encoding {
             };
 
             if delegations_count >= 60 {
-                encode_compact_width_be(delegations_count as u64, consumer).await?;
+                encode_compact_width_be(delegations_count, consumer).await?;
             }
 
             let mut prev_area = out.clone();

--- a/meadowcap/src/mc_subspace_capability.rs
+++ b/meadowcap/src/mc_subspace_capability.rs
@@ -288,7 +288,7 @@ pub(super) mod encoding {
             Encodable::encode(&self.initial_authorisation, consumer).await?;
 
             if delegations_count >= 60 {
-                encode_compact_width_be(delegations_count as u64, consumer).await?;
+                encode_compact_width_be(delegations_count, consumer).await?;
             }
 
             for delegation in self.delegations.iter() {

--- a/meadowcap/src/mc_subspace_capability.rs
+++ b/meadowcap/src/mc_subspace_capability.rs
@@ -267,7 +267,7 @@ pub(super) mod encoding {
         {
             let mut header = 0;
 
-            let delegations_count = self.delegations.len();
+            let delegations_count = self.delegations.len() as u64;
 
             if delegations_count >= 4294967296 {
                 header |= 0b1111_1111;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"


### PR DESCRIPTION
This adds more CI workflows (adapted from iroh):

* Build and test on mac OS
* Build and test on windows
* Build and test on android (aarch64 and armv7)
* Cross-compile and test on i686 (32bit) linux, armv7 linux, aarch64 linux
* Run `cargo fmt` and `cargo clippy` checks
* Use nextest for running tests (runs test in parallel, much faster)
* Runs only fuzz tests on nightly, all others on stable

apart from the CI workflow this

* fixes build failures on 32bit systems by using u64 not usize in more places
* tries to fix some unused import warnings wrt syncify (but failed, added an allow - will have to be revisited)

All green now!