### PR TITLE
Add query methods to Store trait

### DIFF
--- a/data-model/src/lengthy_entry.rs
+++ b/data-model/src/lengthy_entry.rs
@@ -1,4 +1,4 @@
-use crate::{Entry, NamespaceId, PayloadDigest, SubspaceId};
+use crate::{AuthorisationToken, AuthorisedEntry, Entry, NamespaceId, PayloadDigest, SubspaceId};
 
 /// An [`Entry`] together with information about how much of its payload a given [`Store`] holds.
 ///
@@ -29,6 +29,51 @@ where
 
     /// The entry in question.
     pub fn entry(&self) -> &Entry<MCL, MCC, MPL, N, S, PD> {
+        &self.entry
+    }
+
+    /// The number of consecutive bytes from the start of the entry’s Payload that the peer holds.
+    pub fn available(&self) -> u64 {
+        self.available
+    }
+}
+
+/// An [`AuthorisedEntry`] together with information about how much of its payload a given [`Store`] holds.
+pub struct LengthyAuthorisedEntry<
+    const MCL: usize,
+    const MCC: usize,
+    const MPL: usize,
+    N,
+    S,
+    PD,
+    AT,
+> where
+    N: NamespaceId,
+    S: SubspaceId,
+    PD: PayloadDigest,
+    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
+{
+    /// The Entry in question.
+    entry: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
+    /// The number of consecutive bytes from the start of the entry’s payload that the peer holds.
+    available: u64,
+}
+
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
+    LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>
+where
+    N: NamespaceId,
+    S: SubspaceId,
+    PD: PayloadDigest,
+    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
+{
+    /// Create a new lengthy entry from a given [`AuthorisedEntry`] and the number of consecutive bytes from the start of the entry’s payload that are held.
+    pub fn new(entry: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>, available: u64) -> Self {
+        Self { entry, available }
+    }
+
+    /// The entry in question.
+    pub fn entry(&self) -> &AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT> {
         &self.entry
     }
 

--- a/data-model/src/lengthy_entry.rs
+++ b/data-model/src/lengthy_entry.rs
@@ -36,6 +36,23 @@ where
     pub fn available(&self) -> u64 {
         self.available
     }
+
+    /// Turn this into a regular [`Entry`].
+    pub fn into_entry(self) -> Entry<MCL, MCC, MPL, N, S, PD> {
+        self.entry
+    }
+}
+
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>
+    AsRef<Entry<MCL, MCC, MPL, N, S, PD>> for LengthyEntry<MCL, MCC, MPL, N, S, PD>
+where
+    N: NamespaceId,
+    S: SubspaceId,
+    PD: PayloadDigest,
+{
+    fn as_ref(&self) -> &Entry<MCL, MCC, MPL, N, S, PD> {
+        &self.entry
+    }
 }
 
 /// An [`AuthorisedEntry`] together with information about how much of its payload a given [`Store`] holds.
@@ -80,5 +97,24 @@ where
     /// The number of consecutive bytes from the start of the entry’s Payload that the peer holds.
     pub fn available(&self) -> u64 {
         self.available
+    }
+
+    /// Turn this into a [`AuthorisedEntry`].
+    pub fn into_authorised_entry(self) -> AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT> {
+        self.entry
+    }
+}
+
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
+    AsRef<AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>
+    for LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>
+where
+    N: NamespaceId,
+    S: SubspaceId,
+    PD: PayloadDigest,
+    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
+{
+    fn as_ref(&self) -> &AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT> {
+        &self.entry
     }
 }

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -100,16 +100,16 @@ pub enum PayloadAppendError {
 /// Returned when no entry was found for some criteria.
 pub struct NoSuchEntryError;
 
-/// Orderings for a
+/// The order by which entries should be returned for a given query.
 pub enum QueryOrder {
-    /// Ordered by subspace, then path, then timestamp
+    /// Ordered by subspace, then path, then timestamp.
     Subspace,
-    /// Ordered by path, them timestamp, then subspace
+    /// Ordered by path, then by an arbitrary order determined by the implementation.
     Path,
-    /// Ordered by timestamp, then subspace, then path
+    /// Ordered by timestamp, then by an arbitrary order determined by the implementation.
     Timestamp,
-    /// Whichever order is most efficient.
-    Efficient,
+    /// An arbitrary order chosen by the implementation, hopefully the most efficient one.
+    Arbitrary,
 }
 
 /// Describes an [`AuthorisedEntry`] which was pruned and the [`AuthorisedEntry`] which triggered the pruning.

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -98,7 +98,7 @@ pub enum PayloadAppendError {
 }
 
 /// Returned when no entry was found for some criteria.
-pub struct NoSuchEntryError();
+pub struct NoSuchEntryError;
 
 /// Orderings for a
 pub enum QueryOrder {

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -155,7 +155,7 @@ pub struct ResumptionFailedError(pub u64);
 pub struct QueryIgnoreParams {
     /// Omit entries with locally incomplete corresponding payloads.
     pub ignore_incomplete_payloads: bool,
-    /// Omit entries with an empty payload.
+    /// Omit entries whose payload is the empty string.
     pub ignore_empty_payloads: bool,
 }
 

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -6,7 +6,7 @@ use crate::{
     entry::AuthorisedEntry,
     grouping::AreaOfInterest,
     parameters::{AuthorisationToken, NamespaceId, PayloadDigest, SubspaceId},
-    LengthyEntry, Path,
+    LengthyAuthorisedEntry, LengthyEntry, Path,
 };
 
 /// Returned when an entry could be ingested into a [`Store`].
@@ -162,7 +162,7 @@ where
     where
         Producer: BulkProducer<Item = u8>;
 
-    /// Locally forget an entry with a given [path] and [subspace] id, returning the forgotten entry, or an error if no entry with that path and subspace ID are held by this store.
+    /// Locally forget an entry with a given [`Path`] and [subspace](https://willowprotocol.org/specs/data-model/index.html#subspace) id, returning the forgotten entry, or an error if no entry with that path and subspace ID are held by this store.
     ///
     /// If the `traceless` parameter is `true`, the store will keep no record of ever having had the entry. If `false`, it *may* persist what was forgetten for an arbitrary amount of time.
     ///
@@ -225,4 +225,15 @@ where
 
     /// Force persistence of all previous mutations
     fn flush() -> impl Future<Output = Result<(), Self::FlushError>>;
+
+    /// Return a [`LengthyAuthorisedEntry`] with the given [`Path`] and [subspace](https://willowprotocol.org/specs/data-model/index.html#subspace) ID, if present.
+    ///
+    /// If `ignore_incomplete_payloads` is `true`, will return `None` if the entry's corresponding payload  is incomplete, even if there is an entry present.
+    /// If `ignore_empty_payloads` is `true`, will return `None` if the entry's payload length is `0`, even if there is an entry present.
+    fn entry(
+        path: Path<MCL, MCC, MPL>,
+        subspace_id: S,
+        ignore_incomplete_payloads: bool,
+        ignore_empty_payloads: bool,
+    ) -> Option<LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>;
 }

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -147,7 +147,7 @@ where
     Pruned(u64, PruneEvent<MCL, MCC, MPL, N, S, PD, AT>),
 }
 
-/// Returned when the store could not resume a subscription because the provided ID was too outdated or not present.
+/// Returned when the store chooses to not resume a subscription.
 pub struct ResumptionFailedError(pub u64);
 
 /// A [`Store`] is a set of [`AuthorisedEntry`] belonging to a single namespace, and a  (possibly partial) corresponding set of payloads.

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -160,8 +160,6 @@ where
 {
     type FlushError;
     type BulkIngestionError;
-    type EntryProducer: Producer<Item = LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>;
-    type EventProducer: Producer<Item = StoreEvent<MCL, MCC, MPL, N, S, PD, AT>>;
 
     /// The [namespace](https://willowprotocol.org/specs/data-model/index.html#namespace) which all of this store's [`AuthorisedEntry`] belong to.
     fn namespace_id() -> N;
@@ -297,7 +295,7 @@ where
         reverse: bool,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
-    ) -> Self::EntryProducer;
+    ) -> impl Producer<Item = LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>;
 
     /// Subscribe to events concerning entries [included](https://willowprotocol.org/specs/grouping-entries/index.html#area_include) by an [`AreaOfInterest`], returning a producer of `StoreEvent`s which occurred since the moment of calling this function.
     ///
@@ -307,7 +305,7 @@ where
         area: AreaOfInterest<MCL, MCC, MPL, S>,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
-    ) -> Self::EventProducer;
+    ) -> impl Producer<Item = StoreEvent<MCL, MCC, MPL, N, S, PD, AT>>;
 
     /// Attempt to resume a subscription using a *progress ID* obtained from a previous subscription, or return an error if this store implementation is unable to resume the subscription.
     fn resume_subscription(
@@ -315,5 +313,5 @@ where
         area: AreaOfInterest<MCL, MCC, MPL, S>,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
-    ) -> Result<Self::EventProducer, ResumptionFailedError>;
+    ) -> impl Producer<Item = StoreEvent<MCL, MCC, MPL, N, S, PD, AT>>;
 }

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -285,7 +285,7 @@ where
         subspace_id: S,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
-    ) -> Option<LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>;
+    ) -> impl Future<Output = LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>;
 
     /// Query which entries are [included](https://willowprotocol.org/specs/grouping-entries/index.html#area_include) by an [`AreaOfInterest`], returning a producer of [`LengthyAuthorisedEntry`].
     ///

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -203,7 +203,7 @@ where
     /// This method **cannot** verify the integrity of partial payload. This means that arbitrary (and possibly malicious) payloads smaller than the expected size will be stored unless partial verification is implemented upstream (e.g. during [the Willow General Sync Protocol's payload transformation](https://willowprotocol.org/specs/sync/index.html#sync_payloads_transform)).
     fn append_payload<Producer>(
         &self,
-        expected_digest: PD,
+        expected_digest: &PD,
         expected_size: u64,
         producer: &mut Producer,
     ) -> impl Future<Output = Result<PayloadAppendSuccess<MCL, MCC, MPL, N, S, PD>, PayloadAppendError>>
@@ -216,8 +216,9 @@ where
     ///
     /// Forgetting is not the same as deleting! Subsequent joins with other [`Store`]s may bring the forgotten entry back.
     fn forget_entry(
+        &self,
         path: &Path<MCL, MCC, MPL>,
-        subspace_id: S,
+        subspace_id: &S,
         traceless: bool,
     ) -> impl Future<Output = Result<AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>, NoSuchEntryError>>;
 
@@ -227,6 +228,7 @@ where
     ///
     /// Forgetting is not the same as deleting! Subsequent joins with other [`Store`]s may bring the forgotten entries back.
     fn forget_area(
+        &self,
         area: &AreaOfInterest<MCL, MCC, MPL, S>,
         traceless: bool,
     ) -> impl Future<Output = Vec<AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>>;
@@ -237,6 +239,7 @@ where
     ///
     /// Forgetting is not the same as deleting! Subsequent joins with other [`Store`]s may bring the forgotten entries back.
     fn forget_everything_but_area(
+        &self,
         area: &AreaOfInterest<MCL, MCC, MPL, S>,
         traceless: bool,
     ) -> impl Future<Output = Vec<AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>>;
@@ -247,6 +250,7 @@ where
     ///
     /// Forgetting is not the same as deleting! Subsequent joins with other [`Store`]s may bring the forgotten payload back.
     fn forget_payload(
+        &self,
         digest: PD,
         traceless: bool,
     ) -> impl Future<Output = Result<(), NoSuchEntryError>>;
@@ -257,6 +261,7 @@ where
     ///
     /// Forgetting is not the same as deleting! Subsequent joins with other [`Store`]s may bring the forgotten payloads back.
     fn forget_area_payloads(
+        &self,
         area: &AreaOfInterest<MCL, MCC, MPL, S>,
         traceless: bool,
     ) -> impl Future<Output = Vec<PD>>;
@@ -267,6 +272,7 @@ where
     ///
     /// Forgetting is not the same as deleting! Subsequent joins with other [`Store`]s may bring the forgotten payloads back.
     fn forget_everything_but_area_payloads(
+        &self,
         area: &AreaOfInterest<MCL, MCC, MPL, S>,
         traceless: bool,
     ) -> impl Future<Output = Vec<PD>>;
@@ -279,8 +285,9 @@ where
     /// If `ignore_incomplete_payloads` is `true`, will return `None` if the entry's corresponding payload  is incomplete, even if there is an entry present.
     /// If `ignore_empty_payloads` is `true`, will return `None` if the entry's payload length is `0`, even if there is an entry present.
     fn entry(
-        path: Path<MCL, MCC, MPL>,
-        subspace_id: S,
+        &self,
+        path: &Path<MCL, MCC, MPL>,
+        subspace_id: &S,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
     ) -> impl Future<Output = LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>;
@@ -290,8 +297,9 @@ where
     /// If `ignore_incomplete_payloads` is `true`, the producer will not produce entries with incomplete corresponding payloads.
     /// If `ignore_empty_payloads` is `true`, the producer will not produce entries with a `payload_length` of `0`.
     fn query_area(
-        area: AreaOfInterest<MCL, MCC, MPL, S>,
-        order: QueryOrder,
+        &self,
+        area: &AreaOfInterest<MCL, MCC, MPL, S>,
+        order: &QueryOrder,
         reverse: bool,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
@@ -302,15 +310,17 @@ where
     /// If `ignore_incomplete_payloads` is `true`, the producer will not produce entries with incomplete corresponding payloads.
     /// If `ignore_empty_payloads` is `true`, the producer will not produce entries with a `payload_length` of `0`.
     fn subscribe_area(
-        area: AreaOfInterest<MCL, MCC, MPL, S>,
+        &self,
+        area: &AreaOfInterest<MCL, MCC, MPL, S>,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
     ) -> impl Producer<Item = StoreEvent<MCL, MCC, MPL, N, S, PD, AT>>;
 
     /// Attempt to resume a subscription using a *progress ID* obtained from a previous subscription, or return an error if this store implementation is unable to resume the subscription.
     fn resume_subscription(
+        &self,
         progress_id: u64,
-        area: AreaOfInterest<MCL, MCC, MPL, S>,
+        area: &AreaOfInterest<MCL, MCC, MPL, S>,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
     ) -> impl Producer<Item = StoreEvent<MCL, MCC, MPL, N, S, PD, AT>>;

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -21,8 +21,6 @@ pub enum EntryIngestionSuccess<
 > {
     /// The entry was successfully ingested.
     Success,
-    /// The entry was successfully ingested and prefix pruned some entries.
-    SuccessAndPruned(Vec<AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>),
     /// The entry was not ingested because a newer entry with same
     Obsolete {
         /// The obsolete entry which was not ingested.
@@ -114,6 +112,20 @@ pub enum QueryOrder {
     Efficient,
 }
 
+/// Describes an [`AuthorisedEntry`] which was pruned and the [`AuthorisedEntry`] which triggered the pruning.
+pub struct PruneEvent<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
+where
+    N: NamespaceId,
+    S: SubspaceId,
+    PD: PayloadDigest,
+    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
+{
+    /// The entry which was pruned.
+    pub pruned: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
+    /// The entry which triggered the pruning.
+    pub by: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
+}
+
 /// An event which took place within a [`Store`].
 /// Each event includes a *progress ID* which can be used to *resume* a subscription at any point in the future.
 pub enum StoreEvent<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
@@ -131,10 +143,8 @@ where
     EntryForgotten(u64, AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>),
     /// A payload was forgotten.
     PayloadForgotten(u64, PD),
-    /// An entry was overwritten.
-    Overwritten(u64, AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>),
     /// An entry was pruned via prefix pruning.
-    Pruned(u64, AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>),
+    Pruned(u64, PruneEvent<MCL, MCC, MPL, N, S, PD, AT>),
 }
 
 /// Returned when the store could not resume a subscription because the provided ID was too outdated or not present.

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -301,9 +301,9 @@ where
 
     /// Attempt to resume a subscription using a *progress ID* obtained from a previous subscription, or return an error if this store implementation is unable to resume the subscription.
     fn resume_subscription(
+        progress_id: u64,
         area: AreaOfInterest<MCL, MCC, MPL, S>,
         ignore_incomplete_payloads: bool,
         ignore_empty_payloads: bool,
-        progress_id: Option<u64>,
     ) -> Result<Self::EventProducer, ResumptionFailedError>;
 }


### PR DESCRIPTION
Adds query trait methods as detailed in https://github.com/earthstar-project/willow-rs/pull/21#issuecomment-2199568852:

> - query
>     - query entry by pair of path and subspace id
>       - yields Entry, AuthorisationToken, available payload prefix (length)
>       - option to filter out results with incomplete payloads
>     - query entries by area (of interest)
>       - all of the functionality of singleton queries, also
>       - ordering results (arbitrary, PTS (optionally reversed), TSP (optionally reversed), SPT (optionally reversed)) (?)
>     - subscriptions: all queries should also work as long-lived subscriptions
>       - this includes subscription to payload prefix appending
>       - this also includes notifications about overwriting and forgetting things
>     - persistent subscriptions
>       - all subscription notifications come with a u64 *progress id*, client code can stop consuming a subscription at any time and can later (even between program shutdown and restart) resume it at the same point by supplying its progress id
>       - this is a best-effort service, the storage may reject a resumption because it is too outdated
>         - a simplistic implementation can effectively opt out of providing persistent subscriptions by simply considering *all* ids as outdated
>       - forgetting entries/payloads can cause progress ids to become outdated, unless the storage tracks the things it forgot
>         - this is why all *forget* functionality comes with a flag whether it should be completely traceless or whether the storage is allowed to track the act of forgetting

To be merged into #21 