### PR TITLE
WGPS: Add ReadyTransport and friends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,8 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 name = "wgps"
 version = "0.1.0"
 dependencies = [
+ "either",
+ "smol",
  "ufotofu",
  "willow-data-model",
 ]

--- a/wgps/Cargo.toml
+++ b/wgps/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [dependencies]
 willow-data-model = { path = "../data-model", version = "0.1.0" }
 ufotofu = { version = "0.4.2", features = ["std"] }
+either = "1.10.0"
+
+[dev-dependencies]
+smol = "2.0.0"
 
 [lints]
 workspace = true

--- a/wgps/src/lib.rs
+++ b/wgps/src/lib.rs
@@ -7,6 +7,9 @@ use willow_data_model::{
     ResumptionFailedError, Store, StoreEvent, SubspaceId,
 };
 
+mod ready_transport;
+pub use ready_transport::*;
+
 /// Options to specify how ranges should be partitioned.
 #[derive(Debug, Clone, Copy)]
 pub struct PartitionOpts {

--- a/wgps/src/ready_transport.rs
+++ b/wgps/src/ready_transport.rs
@@ -30,14 +30,14 @@ impl<E: core::fmt::Display> core::fmt::Display for ReadyTransportError<E> {
 
 /** The result of intercepting the first few bytes of a WGPS transport. */
 #[derive(Debug)]
-pub struct ReadyTransport<
+pub(crate) struct ReadyTransport<
     const CHALLENGE_HASH_LENGTH: usize,
     E: core::fmt::Display,
     P: Producer<Item = u8, Final = (), Error = E>,
 > {
     /** The maximum payload size which may be sent without being explicitly requested.*/
     pub maximum_payload_size: usize,
-    /** The challenge hash of a nonce */
+    /** The challenge hash of a nonce. */
     pub received_commitment: [u8; CHALLENGE_HASH_LENGTH],
     /** A 'ready' transport set to immediately produce encoded WGPS messages. */
     pub transport: P,
@@ -45,7 +45,7 @@ pub struct ReadyTransport<
 
 /** Given a producer of bytes which is to immediately produce the bytes corresponding to the WGPS' [maximum payload size](https://willowprotocol.org/specs/sync/index.html#peer_max_payload_size) and [received commitment](https://willowprotocol.org/specs/sync/index.html#received_commitment), returns the computed maximum payload size, received commitment, and a 'ready' transport set to produce encoded WGPS messages.
 */
-pub async fn ready_transport<
+pub(crate) async fn ready_transport<
     const CHALLENGE_HASH_LENGTH: usize,
     E: core::fmt::Display,
     P: Producer<Item = u8, Final = (), Error = E>,

--- a/wgps/src/ready_transport.rs
+++ b/wgps/src/ready_transport.rs
@@ -1,0 +1,173 @@
+use either::Either;
+use ufotofu::local_nb::Producer;
+
+/** When things go wrong while trying to make a WGPS transport ready. */
+#[derive(Debug)]
+pub enum ReadyTransportError<E: core::fmt::Display> {
+    /** The transport returned an error of its own. */
+    Transport(E),
+    /** The received max payload power was invalid, i.e. greater than 64. */
+    MaxPayloadInvalid,
+    /** The transport stopped producing bytes before it could be deemed ready. */
+    FinishedTooSoon,
+}
+
+impl<E: core::fmt::Display> core::fmt::Display for ReadyTransportError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadyTransportError::Transport(e) => write!(f, "{}", e),
+            ReadyTransportError::MaxPayloadInvalid => write!(
+                f,
+                "The received max payload power was invalid, i.e. greater than 64."
+            ),
+            ReadyTransportError::FinishedTooSoon => write!(
+                f,
+                "The transport stopped producing bytes before it could be deemed ready."
+            ),
+        }
+    }
+}
+
+/** The result of intercepting the first few bytes of a WGPS transport. */
+#[derive(Debug)]
+pub struct ReadyTransport<
+    const CHALLENGE_HASH_LENGTH: usize,
+    E: core::fmt::Display,
+    P: Producer<Item = u8, Final = (), Error = E>,
+> {
+    /** The maximum payload size which may be sent without being explicitly requested.*/
+    pub maximum_payload_size: usize,
+    /** The challenge hash of a nonce */
+    pub received_commitment: [u8; CHALLENGE_HASH_LENGTH],
+    /** A 'ready' transport set to immediately produce encoded WGPS messages. */
+    pub transport: P,
+}
+
+/** Given a producer of bytes which is to immediately produce the bytes corresponding to the WGPS' [maximum payload size](https://willowprotocol.org/specs/sync/index.html#peer_max_payload_size) and [received commitment](https://willowprotocol.org/specs/sync/index.html#received_commitment), returns the computed maximum payload size, received commitment, and a 'ready' transport set to produce encoded WGPS messages.
+*/
+pub async fn ready_transport<
+    const CHALLENGE_HASH_LENGTH: usize,
+    E: core::fmt::Display,
+    P: Producer<Item = u8, Final = (), Error = E>,
+>(
+    mut transport: P,
+) -> Result<ReadyTransport<CHALLENGE_HASH_LENGTH, E, P>, ReadyTransportError<E>> {
+    let maximum_payload_power = match transport.produce().await {
+        Ok(either) => match either {
+            Either::Left(byte) => Ok(byte),
+            Either::Right(_) => Err(ReadyTransportError::FinishedTooSoon),
+        },
+        Err(transport_err) => Err(ReadyTransportError::Transport(transport_err)),
+    }?;
+
+    if maximum_payload_power > 64 {
+        return Err(ReadyTransportError::MaxPayloadInvalid);
+    }
+
+    let maximum_payload_size = 2_usize.pow(maximum_payload_power as u32);
+
+    let mut received_commitment = [0_u8; CHALLENGE_HASH_LENGTH];
+
+    for commitment_byte in received_commitment.iter_mut() {
+        match transport.produce().await {
+            Ok(either) => match either {
+                Either::Left(byte) => {
+                    *commitment_byte = byte;
+                }
+                Either::Right(_) => return Err(ReadyTransportError::FinishedTooSoon),
+            },
+            Err(transport_err) => return Err(ReadyTransportError::Transport(transport_err)),
+        };
+    }
+
+    Ok(ReadyTransport {
+        maximum_payload_size,
+        received_commitment,
+        transport,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    use ufotofu::local_nb::producer::FromSlice;
+
+    #[test]
+    fn empty_producer() {
+        let empty_transport = FromSlice::new(&[]);
+
+        smol::block_on(async {
+            let result = ready_transport::<4, _, _>(empty_transport).await;
+
+            assert!(matches!(result, Err(ReadyTransportError::FinishedTooSoon)))
+        });
+    }
+
+    #[test]
+    fn only_power_producer() {
+        let only_power_transport = FromSlice::new(&[0_u8]);
+
+        smol::block_on(async {
+            let result = ready_transport::<4, _, _>(only_power_transport).await;
+
+            assert!(matches!(result, Err(ReadyTransportError::FinishedTooSoon)))
+        });
+    }
+
+    #[test]
+    fn invalid_power_producer() {
+        let only_power_transport = FromSlice::new(&[65_u8]);
+
+        smol::block_on(async {
+            let result = ready_transport::<4, _, _>(only_power_transport).await;
+
+            assert!(matches!(
+                result,
+                Err(ReadyTransportError::MaxPayloadInvalid)
+            ))
+        });
+    }
+
+    #[test]
+    fn invalid_power_producer_correct_length() {
+        let only_power_transport = FromSlice::new(&[65_u8, 0, 0, 0, 0]);
+
+        smol::block_on(async {
+            let result = ready_transport::<4, _, _>(only_power_transport).await;
+
+            assert!(matches!(
+                result,
+                Err(ReadyTransportError::MaxPayloadInvalid)
+            ))
+        });
+    }
+
+    #[test]
+    fn commitment_too_short() {
+        let only_power_transport = FromSlice::new(&[0_u8, 0]);
+
+        smol::block_on(async {
+            let result = ready_transport::<4, _, _>(only_power_transport).await;
+
+            assert!(matches!(result, Err(ReadyTransportError::FinishedTooSoon)))
+        });
+    }
+
+    #[test]
+    fn success() {
+        let only_power_transport = FromSlice::new(&[1_u8, 1, 2, 3, 4, 5]);
+
+        smol::block_on(async {
+            let result = ready_transport::<4, _, _>(only_power_transport).await;
+
+            if let Ok(ready) = result {
+                assert!(ready.maximum_payload_size == 2);
+                assert!(ready.received_commitment == [1, 2, 3, 4]);
+            } else {
+                panic!()
+            }
+        });
+    }
+}

--- a/wgps/src/ready_transport.rs
+++ b/wgps/src/ready_transport.rs
@@ -30,6 +30,7 @@ impl<E: core::fmt::Display> core::fmt::Display for ReadyTransportError<E> {
 
 /** The result of intercepting the first few bytes of a WGPS transport. */
 #[derive(Debug)]
+#[allow(dead_code)] // TODO: Remove when this is used.
 pub(crate) struct ReadyTransport<
     const CHALLENGE_HASH_LENGTH: usize,
     E: core::fmt::Display,
@@ -43,8 +44,21 @@ pub(crate) struct ReadyTransport<
     pub transport: P,
 }
 
+impl<
+        const CHALLENGE_HASH_LENGTH: usize,
+        E: core::fmt::Display,
+        P: BulkProducer<Item = u8, Final = (), Error = E>,
+    > ReadyTransport<CHALLENGE_HASH_LENGTH, E, P>
+{
+    #[allow(dead_code)] // TODO: Remove when this is used.
+    pub(crate) fn transport(&self) -> &P {
+        &self.transport
+    }
+}
+
 /** Given a producer of bytes which is to immediately produce the bytes corresponding to the WGPS' [maximum payload size](https://willowprotocol.org/specs/sync/index.html#peer_max_payload_size) and [received commitment](https://willowprotocol.org/specs/sync/index.html#received_commitment), returns the computed maximum payload size, received commitment, and a 'ready' transport set to produce encoded WGPS messages.
 */
+#[allow(dead_code)] // TODO: Remove when this is used.
 pub(crate) async fn ready_transport<
     const CHALLENGE_HASH_LENGTH: usize,
     E: core::fmt::Display,


### PR DESCRIPTION
A small function for intercepting the first few bytes of a WGPS session in order to return the session's maximum payload size, received commitment, and transport set to immediately start returning encoded WGPS messages.