### PR TITLE
Restructure sync_with_peer to allow for dependencies between steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
+name = "async_cell"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834eee9ce518130a3b4d5af09ecc43e9d6b57ee76613f227a1ddd6b77c7a62bc"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +626,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 name = "wgps"
 version = "0.1.0"
 dependencies = [
+ "async_cell",
  "either",
  "futures",
  "smol",

--- a/wgps/Cargo.toml
+++ b/wgps/Cargo.toml
@@ -9,6 +9,7 @@ willow-encoding = { path = "../encoding", version = "0.1.0" }
 ufotofu = { version = "0.4.2", features = ["std"] }
 futures = { version = "0.3.31" }
 either = "1.10.0"
+async_cell = "0.2.2"
 
 [dev-dependencies]
 smol = "2.0.0"

--- a/wgps/src/commitment_scheme/send_prelude.rs
+++ b/wgps/src/commitment_scheme/send_prelude.rs
@@ -3,13 +3,13 @@ use ufotofu::{local_nb::BulkConsumer, nb::ConsumeFullSliceError};
 /// Sends the prelude of maximum payload power and what is to be the recipient's `received_commitment` via a transport.
 pub(crate) async fn send_prelude<const CHALLENGE_HASH_LENGTH: usize, C: BulkConsumer<Item = u8>>(
     max_payload_power: u8,
-    commitment: [u8; CHALLENGE_HASH_LENGTH],
+    commitment: &[u8; CHALLENGE_HASH_LENGTH],
     transport: &mut C,
 ) -> Result<(), C::Error> {
     transport.consume(max_payload_power).await?;
 
     if let Err(ConsumeFullSliceError { reason, .. }) =
-        transport.bulk_consume_full_slice(&commitment).await
+        transport.bulk_consume_full_slice(commitment).await
     {
         return Err(reason);
     }

--- a/wgps/src/messages/commitment_reveal.rs
+++ b/wgps/src/messages/commitment_reveal.rs
@@ -1,11 +1,11 @@
 use ufotofu::local_nb::BulkConsumer;
 use willow_encoding::Encodable;
 
-pub struct CommitmentReveal<const CHALLENGE_LENGTH: usize> {
-    pub nonce: [u8; CHALLENGE_LENGTH],
+pub struct CommitmentReveal<'nonce, const CHALLENGE_LENGTH: usize> {
+    pub nonce: &'nonce [u8; CHALLENGE_LENGTH],
 }
 
-impl<const CHALLENGE_LENGTH: usize> Encodable for CommitmentReveal<CHALLENGE_LENGTH> {
+impl<'nonce, const CHALLENGE_LENGTH: usize> Encodable for CommitmentReveal<'nonce, CHALLENGE_LENGTH> {
     async fn encode<Consumer>(&self, consumer: &mut Consumer) -> Result<(), Consumer::Error>
     where
         Consumer: BulkConsumer<Item = u8>,

--- a/wgps/src/parameters.rs
+++ b/wgps/src/parameters.rs
@@ -1,3 +1,3 @@
 pub trait ChallengeHash<const CHALLENGE_LENGTH: usize, const CHALLENGE_HASH_LENGTH: usize> {
-    fn hash(nonce: [u8; CHALLENGE_LENGTH]) -> [u8; CHALLENGE_HASH_LENGTH];
+    fn hash(nonce: &[u8; CHALLENGE_LENGTH]) -> [u8; CHALLENGE_HASH_LENGTH];
 }


### PR DESCRIPTION
Also changes some function arguments to be references instead of owned values. We should try getting those right immediately when sketching code.