### PR TITLE
wb_async_utils cleanup

### DIFF
--- a/wb_async_utils/src/lib.rs
+++ b/wb_async_utils/src/lib.rs
@@ -15,3 +15,17 @@ pub mod spsc;
 
 #[cfg(feature = "ufotofu_utils")]
 pub mod shared_producer;
+
+// This is safe if and only if the object pointed at by `reference` lives for at least `'longer`.
+// See https://doc.rust-lang.org/nightly/std/intrinsics/fn.transmute.html for more detail.
+pub(crate) unsafe fn extend_lifetime<'shorter, 'longer, T: ?Sized>(reference: &'shorter T) -> &'longer T {
+    core::mem::transmute::<&'shorter T, &'longer T>(reference)
+}
+
+// This is safe if and only if the object pointed at by `reference` lives for at least `'longer`.
+// See https://doc.rust-lang.org/nightly/std/intrinsics/fn.transmute.html for more detail.
+pub(crate) unsafe fn extend_lifetime_mut<'shorter, 'longer, T: ?Sized>(
+    reference: &'shorter mut T,
+) -> &'longer mut T {
+    core::mem::transmute::<&'shorter mut T, &'longer mut T>(reference)
+}

--- a/wb_async_utils/src/mutex.rs
+++ b/wb_async_utils/src/mutex.rs
@@ -23,6 +23,13 @@ pub struct Mutex<T> {
 
 impl<T> Mutex<T> {
     /// Creates a new mutex storing the given value.
+    /// 
+    /// ```
+    /// use wb_async_utils::mutex::*;
+    ///
+    /// let m = Mutex::new(5);
+    /// assert_eq!(5, m.into_inner());
+    /// ```
     pub fn new(value: T) -> Self {
         Mutex {
             value: FairlyUnsafeCell::new(value),
@@ -104,7 +111,7 @@ impl<T> Mutex<T> {
     ///     *handle.deref_mut() = 1;
     /// }, async {
     ///     // This future is "faster", but has to wait for the "work" performed by the first one.
-    ///     let mut handle = m.read().await;
+    ///     let mut handle = m.write().await;
     ///     assert_eq!(1, *handle.deref());
     /// }));
     /// ```

--- a/wb_async_utils/src/mutex.rs
+++ b/wb_async_utils/src/mutex.rs
@@ -383,7 +383,7 @@ impl<T> Deref for ReadGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        let borrowed = unsafe { self.mutex.value.borrow() }; // Safe because a ReadGuard can never live at the same time as a WriteGuard or a `&mut Mutex`.
+        let borrowed = unsafe { self.mutex.value.borrow() }; // Safe because a ReadGuard can never live at the same time as another guard or a `&mut Mutex`.
                                                                // We can only obtain references with a lifetime tied to `borrowed`, but we know the refs to be both alive and exclusive for as long
                                                                // as `self`.
         unsafe { extend_lifetime(borrowed.deref()) }
@@ -429,7 +429,7 @@ impl<T> Deref for WriteGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        let borrowed = unsafe { self.mutex.value.borrow() }; // Safe because a ReadGuard can never live at the same time as a WriteGuard or a `&mut Mutex`.
+        let borrowed = unsafe { self.mutex.value.borrow() }; // Safe because a WriteGuard can never live at the same time as another guard or a `&mut Mutex`.
                                                                // We can only obtain references with a lifetime tied to `borrowed`, but we know the refs to be both alive and exclusive for as long
                                                                // as `self`.
         unsafe { extend_lifetime(borrowed.deref()) }
@@ -438,7 +438,7 @@ impl<T> Deref for WriteGuard<'_, T> {
 
 impl<T> DerefMut for WriteGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
-        let mut borrowed = unsafe { self.mutex.value.borrow_mut() }; // Safe because a ReadGuard can never live at the same time as a WriteGuard or a `&mut Mutex`.
+        let mut borrowed = unsafe { self.mutex.value.borrow_mut() }; // Safe because a WriteGuard can never live at the same time as another or a `&mut Mutex`.
                                                                        // We can only obtain references with a lifetime tied to `borrowed`, but we know the refs to be both alive and exclusive for as long
                                                                        // as `self`.
         unsafe { extend_lifetime_mut(borrowed.deref_mut()) }

--- a/wb_async_utils/src/once_cell.rs
+++ b/wb_async_utils/src/once_cell.rs
@@ -1,17 +1,23 @@
 use core::{
-    cell::UnsafeCell,
     future::Future,
     pin::Pin,
     task::{Context, Poll, Waker},
 };
-use std::collections::VecDeque;
 use std::fmt;
+use std::{
+    collections::VecDeque,
+    ops::{Deref, DerefMut},
+};
+
+use fairly_unsafe_cell::FairlyUnsafeCell;
+
+use crate::extend_lifetime;
 
 /// An optional value that can be set to a `Some` at most once, and which allows to `.await` that time.
 ///
 /// All accesses before setting the value are parked and waked in FIFO order.
 pub struct OnceCell<T> {
-    state: UnsafeCell<State<T>>, // No references to this escape the lifeitme of a method, and each method creates at most one reference.
+    state: FairlyUnsafeCell<State<T>>, // No references to this escape the lifeitme of a method, and each method creates at most one reference.
 }
 
 enum State<T> {
@@ -36,7 +42,7 @@ impl<T> OnceCell<T> {
     /// ```
     pub fn new() -> Self {
         OnceCell {
-            state: UnsafeCell::new(State::Empty(VecDeque::new())),
+            state: FairlyUnsafeCell::new(State::Empty(VecDeque::new())),
         }
     }
 
@@ -50,7 +56,7 @@ impl<T> OnceCell<T> {
     /// ```
     pub fn new_with(t: T) -> Self {
         OnceCell {
-            state: UnsafeCell::new(State::Set(t)),
+            state: FairlyUnsafeCell::new(State::Set(t)),
         }
     }
 
@@ -70,61 +76,65 @@ impl<T> OnceCell<T> {
     }
 
     /// Returns whether the [`OnceCell`] is currently empty.
-    /// 
+    ///
     /// ```
     /// use wb_async_utils::OnceCell;
-    /// 
+    ///
     /// let c1 = OnceCell::<()>::new();
     /// assert!(c1.is_empty());
-    /// 
+    ///
     /// let c2 = OnceCell::new_with(17);
     /// assert!(!c2.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
-        match unsafe { &mut *self.state.get() } {
+        match unsafe { self.state.borrow().deref() } {
             State::Empty(_) => true,
             State::Set(_) => false,
         }
     }
 
     /// Obtain a mutable reference to the stored value, or `None` if nothing is stored.
-    /// 
+    ///
     /// ```
     /// use wb_async_utils::OnceCell;
-    /// 
+    ///
     /// let mut c1 = OnceCell::<()>::new();
     /// assert_eq!(None, c1.try_get_mut());
-    /// 
+    ///
     /// let mut c2 = OnceCell::new_with(17);
     /// assert_eq!(Some(&mut 17), c2.try_get_mut());
     /// ```
     pub fn try_get_mut(&mut self) -> Option<&mut T> {
-        match unsafe { &mut *self.state.get() } {
+        match self.state.get_mut() {
             State::Empty(_) => None,
             State::Set(ref mut t) => Some(t),
         }
     }
 
     /// Try to obtain an immutable reference to the stored value, or `None` if nothing is stored.
-    /// 
+    ///
     /// ```
     /// use wb_async_utils::OnceCell;
-    /// 
+    ///
     /// let c1 = OnceCell::<()>::new();
     /// assert_eq!(None, c1.try_get());
-    /// 
+    ///
     /// let c2 = OnceCell::new_with(17);
     /// assert_eq!(Some(&17), c2.try_get());
     /// ```
     pub fn try_get(&self) -> Option<&T> {
-        match unsafe { &*self.state.get() } {
+        match unsafe { self.state.borrow().deref() } {
             State::Empty(_) => None,
-            State::Set(ref t) => Some(t),
+            State::Set(ref t) => Some(unsafe {
+                // As long as `&self` is alive, it is impossible to get mutable access to the stored value,
+                // since `try_get_mut` needs a mutable reference to the cell.
+                extend_lifetime(t)
+            }),
         }
     }
 
     /// Obtain an immutable reference to the stored value, `.await`ing it to be set if necessary.
-    /// 
+    ///
     /// ```
     /// use wb_async_utils::OnceCell;
     ///
@@ -143,7 +153,7 @@ impl<T> OnceCell<T> {
     }
 
     /// Set the value in the cell if it was empty before, return an error and do nothing if is was not empty.
-    /// 
+    ///
     /// ```
     /// use wb_async_utils::OnceCell;
     ///
@@ -159,7 +169,7 @@ impl<T> OnceCell<T> {
     /// });
     /// ```
     pub fn set(&self, t: T) -> Result<(), T> {
-        match unsafe { &mut *self.state.get() } {
+        match unsafe { self.state.borrow_mut().deref_mut() } {
             State::Empty(queue) => {
                 for waker in queue.iter() {
                     waker.wake_by_ref();
@@ -169,7 +179,7 @@ impl<T> OnceCell<T> {
         }
 
         unsafe {
-            *self.state.get() = State::Set(t);
+            *self.state.borrow_mut().deref_mut() = State::Set(t);
         }
 
         Ok(())
@@ -197,12 +207,16 @@ impl<'cell, T> Future for GetFuture<'cell, T> {
     type Output = &'cell T;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match unsafe { &mut *self.0.state.get() } {
+        match unsafe { &mut self.0.state.borrow_mut().deref_mut() } {
             State::Empty(queue) => {
                 queue.push_back(cx.waker().clone());
                 Poll::Pending
             }
-            State::Set(ref t) => Poll::Ready(t),
+            State::Set(ref t) => Poll::Ready(unsafe {
+                // As long as the reference to the cell is alive, it is impossible to get mutable access to the stored value,
+                // since `try_get_mut` needs a mutable reference to the cell.
+                extend_lifetime(t)
+            }),
         }
     }
 }

--- a/wb_async_utils/src/spsc.rs
+++ b/wb_async_utils/src/spsc.rs
@@ -22,7 +22,7 @@ use std::{
 use ufotofu::{BufferedConsumer, BufferedProducer, BulkConsumer, BulkProducer, Consumer, Producer};
 use ufotofu_queues::Queue;
 
-use crate::{Mutex, TakeCell};
+use crate::{extend_lifetime, extend_lifetime_mut, Mutex, TakeCell};
 
 /// The state shared between the [`Sender`] and the [`Receiver`]. This is fully opaque, but we expose it to give control over where it is allocated.
 #[derive(Debug)]
@@ -396,20 +396,6 @@ impl<R: Deref<Target = State<Q, F, E>>, Q: Queue, F, E> BulkProducer for Receive
         self.state.notify_the_sender.set(());
         Ok(())
     }
-}
-
-// This is safe if and only if the object pointed at by `reference` lives for at least `'longer`.
-// See https://doc.rust-lang.org/nightly/std/intrinsics/fn.transmute.html for more detail.
-unsafe fn extend_lifetime<'shorter, 'longer, T: ?Sized>(reference: &'shorter T) -> &'longer T {
-    std::mem::transmute::<&'shorter T, &'longer T>(reference)
-}
-
-// This is safe if and only if the object pointed at by `reference` lives for at least `'longer`.
-// See https://doc.rust-lang.org/nightly/std/intrinsics/fn.transmute.html for more detail.
-unsafe fn extend_lifetime_mut<'shorter, 'longer, T: ?Sized>(
-    reference: &'shorter mut T,
-) -> &'longer mut T {
-    std::mem::transmute::<&'shorter mut T, &'longer mut T>(reference)
 }
 
 #[cfg(test)]

--- a/wb_async_utils/src/take_cell.rs
+++ b/wb_async_utils/src/take_cell.rs
@@ -152,7 +152,6 @@ impl<T> TakeCell<T> {
     /// Takes the current value out of the cell if there is one, waiting for one to arrive if necessary.
     ///
     /// ```
-    /// use futures::join;
     /// use wb_async_utils::TakeCell;
     ///
     /// let cell = TakeCell::new_with(5);


### PR DESCRIPTION
Adds basic doc tests to the wb_async_utils crate, and changes the implementation of the utils from using UnsafeCell to using FairlyUnsafeCell.