### PR TITLE
Meadowcap + ufotofu_codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ name = "meadowcap"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "compact_u64",
  "either",
  "signature",
  "ufotofu",

--- a/fuzz/fuzz_targets/enc_mccapability_rel_area.rs
+++ b/fuzz/fuzz_targets/enc_mccapability_rel_area.rs
@@ -3,9 +3,8 @@
 use meadowcap::McCapability;
 use ufotofu_codec::{fuzz_relative_all, Blame};
 use willow_data_model::grouping::Area;
-use willow_fuzz::{
-    placeholder_params::FakeSubspaceId,
-    silly_sigs::{SillyPublicKey, SillySig},
-};
+use willow_fuzz::silly_sigs::{SillyPublicKey, SillySig};
 
-fuzz_relative_all!(McCapability<16, 16, 16, SillyPublicKey, SillySig, SillyPublicKey, SillySig>; Area<16, 16, 16, SillyPublicKey>; Blame; Blame);
+fuzz_relative_all!(McCapability<16, 16, 16, SillyPublicKey, SillySig, SillyPublicKey, SillySig>; Area<16, 16, 16, SillyPublicKey>; Blame; Blame; |cap: &McCapability<16, 16, 16, SillyPublicKey, SillySig, SillyPublicKey, SillySig>, area: &Area<16, 16, 16, SillyPublicKey>| {
+    area.includes_area(&cap.granted_area())
+});

--- a/fuzz/fuzz_targets/mc_is_authorised_write.rs
+++ b/fuzz/fuzz_targets/mc_is_authorised_write.rs
@@ -3,10 +3,10 @@
 use libfuzzer_sys::fuzz_target;
 use meadowcap::{AccessMode, McAuthorisationToken};
 use signature::Signer;
-use ufotofu::sync::consumer::IntoVec;
+use ufotofu::consumer::IntoVec;
+use ufotofu_codec::{Encodable, EncodableSync};
 use willow_data_model::AuthorisationToken;
 use willow_data_model::Entry;
-use willow_encoding::sync::Encodable;
 use willow_fuzz::{
     placeholder_params::FakePayloadDigest,
     silly_sigs::{SillyPublicKey, SillySig},
@@ -21,9 +21,7 @@ fuzz_target!(|data: (
     let is_within_granted_area = token.capability.granted_area().includes_entry(&entry);
     let is_write_cap = token.capability.access_mode() == AccessMode::Write;
 
-    let mut consumer = IntoVec::<u8>::new();
-    entry.encode(&mut consumer).unwrap();
-    let message = consumer.into_vec();
+    let message = entry.sync_encode_into_boxed_slice();
 
     let expected_sig = token
         .capability

--- a/fuzz/src/placeholder_params.rs
+++ b/fuzz/src/placeholder_params.rs
@@ -1,7 +1,7 @@
 use arbitrary::Arbitrary;
 use ufotofu::{BulkConsumer, BulkProducer};
 use ufotofu_codec::{
-    Blame, Decodable, DecodableCanonic, DecodeError, Encodable, EncodableKnownSize,
+    Blame, Decodable, DecodableCanonic, DecodeError, Encodable, EncodableKnownSize, EncodableSync,
 };
 use willow_data_model::{NamespaceId, PayloadDigest, SubspaceId};
 
@@ -204,5 +204,7 @@ impl EncodableKnownSize for FakePayloadDigest {
         32
     }
 }
+
+impl EncodableSync for FakePayloadDigest {}
 
 impl PayloadDigest for FakePayloadDigest {}

--- a/fuzz/src/silly_sigs.rs
+++ b/fuzz/src/silly_sigs.rs
@@ -1,7 +1,9 @@
 use arbitrary::Arbitrary;
 use meadowcap::IsCommunal;
 use signature::{Error as SignatureError, Signer, Verifier};
-use ufotofu_codec::{Blame, Decodable, DecodableCanonic, Encodable};
+use ufotofu_codec::{
+    Blame, Decodable, DecodableCanonic, Encodable, EncodableKnownSize, EncodableSync,
+};
 use willow_data_model::{NamespaceId, SubspaceId};
 
 /// A silly, trivial, insecure public key for fuzz testing.
@@ -86,6 +88,14 @@ impl Encodable for SillyPublicKey {
     }
 }
 
+impl EncodableKnownSize for SillyPublicKey {
+    fn len_of_encoding(&self) -> usize {
+        1
+    }
+}
+
+impl EncodableSync for SillyPublicKey {}
+
 impl Decodable for SillyPublicKey {
     type ErrorReason = Blame;
 
@@ -128,6 +138,14 @@ impl Encodable for SillySig {
         Ok(())
     }
 }
+
+impl EncodableKnownSize for SillySig {
+    fn len_of_encoding(&self) -> usize {
+        1
+    }
+}
+
+impl EncodableSync for SillySig {}
 
 impl Decodable for SillySig {
     type ErrorReason = Blame;

--- a/meadowcap/Cargo.toml
+++ b/meadowcap/Cargo.toml
@@ -16,10 +16,12 @@ arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
 either = "1.13.0"
 willow-encoding = { path = "../encoding", version = "0.1.0" }
 willow-data-model = { path = "../data-model", version = "0.1.0" }
+compact_u64 = { path = "../compact_u64", features = [ "std", "dev" ] }
 
 [dependencies.ufotofu_codec]
 path = "../ufotofu_codec"
 version = "0.1.0"
+features = ["alloc"]
 
 
 [lints]

--- a/meadowcap/src/communal_capability.rs
+++ b/meadowcap/src/communal_capability.rs
@@ -1,5 +1,7 @@
 use signature::{Signer, Verifier};
-use ufotofu_codec::Encodable;
+use ufotofu_codec::{
+    Encodable, EncodableKnownSize, EncodableSync, RelativeEncodable, RelativeEncodableKnownSize,
+};
 use willow_data_model::{grouping::Area, NamespaceId, SubspaceId};
 
 use crate::{AccessMode, Delegation, FailedDelegationError, InvalidDelegationError, IsCommunal};
@@ -34,9 +36,9 @@ pub struct CommunalCapability<
     UserPublicKey,
     UserSignature,
 > where
-    NamespacePublicKey: NamespaceId + Encodable + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
-    UserSignature: Encodable,
+    NamespacePublicKey: NamespaceId + EncodableSync + EncodableKnownSize + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize,
 {
     access_mode: AccessMode,
     namespace_key: NamespacePublicKey,
@@ -53,9 +55,9 @@ impl<
         UserSignature,
     > CommunalCapability<MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
 where
-    NamespacePublicKey: NamespaceId + Encodable + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
-    UserSignature: Encodable + Clone,
+    NamespacePublicKey: NamespaceId + EncodableSync + EncodableKnownSize + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     /// Creates a new communal capability granting access to the [`SubspaceId`] corresponding to the given `UserPublicKey`.
     pub fn new(
@@ -97,11 +99,18 @@ where
 
         let prev_user = self.receiver();
 
-        let handover = self.handover(new_area, new_user);
-        let signature = secret_key.sign(&handover);
+        let handover = CommunalHandover {
+            cap: self,
+            area: new_area,
+            user: new_user,
+        };
+
+        let handover_enc = &handover.sync_encode_into_boxed_slice();
+
+        let signature = secret_key.sign(&handover_enc);
 
         prev_user
-            .verify(&handover, &signature)
+            .verify(&handover_enc, &signature)
             .map_err(|_| FailedDelegationError::WrongSecretForUser(self.receiver().clone()))?;
 
         let mut new_delegations = self.delegations.clone();
@@ -136,17 +145,23 @@ where
             });
         }
 
-        let handover = self.handover(new_area, new_user);
+        let handover = CommunalHandover {
+            cap: self,
+            area: new_area,
+            user: new_user,
+        };
 
         let prev_receiver = self.receiver();
 
-        prev_receiver.verify(&handover, new_sig).map_err(|_| {
-            InvalidDelegationError::InvalidSignature {
+        let handover_slice = handover.sync_encode_into_boxed_slice();
+
+        prev_receiver
+            .verify(&handover_slice, new_sig)
+            .map_err(|_| InvalidDelegationError::InvalidSignature {
                 claimed_receiver: new_user.clone(),
                 expected_signatory: prev_receiver.clone(),
                 signature: new_sig.clone(),
-            }
-        })?;
+            })?;
 
         self.delegations.push(delegation);
 
@@ -220,48 +235,135 @@ where
     pub fn progenitor(&self) -> &UserPublicKey {
         &self.user_key
     }
+}
 
-    /// Returns a bytestring to be signed for a new [`Delegation`].
-    ///
-    /// [Definition](https://willowprotocol.org/specs/meadowcap/index.html#communal_handover)
-    fn handover(
-        &self,
-        new_area: &Area<MCL, MCC, MPL, UserPublicKey>,
-        new_user: &UserPublicKey,
-    ) -> Box<[u8]> {
-        todo!("Implement with new Encoding trait that requires knowing the size upfront by computing the size of the handover first, allocating it as a boxed slice, and then using an ufotofu::into_slice encoder.");
-        // let mut consumer = IntoVec::<u8>::new();
+/// Can be encoded to a bytestring to be signed for a new [`Delegation`] to a [`CommunalCapability`].
+///
+/// [Definition](https://willowprotocol.org/specs/meadowcap/index.html#communal_handover)
+pub struct CommunalHandover<
+    'a,
+    const MCL: usize,
+    const MCC: usize,
+    const MPL: usize,
+    NamespacePublicKey,
+    UserPublicKey,
+    UserSignature,
+> where
+    NamespacePublicKey: NamespaceId + EncodableSync + EncodableKnownSize + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize,
+{
+    cap: &'a CommunalCapability<MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>,
+    area: &'a Area<MCL, MCC, MPL, UserPublicKey>,
+    user: &'a UserPublicKey,
+}
 
-        // if self.delegations.is_empty() {
-        //     let first_byte = match self.access_mode {
-        //         AccessMode::Read => 0x00,
-        //         AccessMode::Write => 0x01,
-        //     };
+impl<
+        'a,
+        const MCL: usize,
+        const MCC: usize,
+        const MPL: usize,
+        NamespacePublicKey,
+        UserPublicKey,
+        UserSignature,
+    > Encodable
+    for CommunalHandover<'a, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
+where
+    NamespacePublicKey: NamespaceId + EncodableSync + EncodableKnownSize + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize,
+{
+    async fn encode<C>(&self, consumer: &mut C) -> Result<(), C::Error>
+    where
+        C: ufotofu::BulkConsumer<Item = u8>,
+    {
+        if self.cap.delegations.is_empty() {
+            let first_byte = match self.cap.access_mode {
+                AccessMode::Read => 0x00,
+                AccessMode::Write => 0x01,
+            };
 
-        //     let prev_area =
-        //         Area::<MCL, MCC, MPL, UserPublicKey>::new_subspace(self.user_key.clone());
+            let prev_area =
+                Area::<MCL, MCC, MPL, UserPublicKey>::new_subspace(self.cap.user_key.clone());
 
-        //     // We can safely unwrap all these encodings as IntoVec's error is the never type.
-        //     consumer.consume(first_byte).unwrap();
-        //     self.namespace_key.encode(&mut consumer).unwrap();
-        //     new_area.relative_encode(&prev_area, &mut consumer).unwrap();
-        //     new_user.encode(&mut consumer).unwrap();
+            // We can safely unwrap all these encodings as IntoVec's error is the never type.
+            consumer.consume(first_byte).await?;
+            self.cap.namespace_key.encode(consumer).await?;
+            self.area.relative_encode(consumer, &prev_area).await?;
+            self.user.encode(consumer).await?;
 
-        //     return consumer.into_vec().into();
-        // }
+            return Ok(());
+        }
 
-        // // We can unwrap here because we know that self.delegations is not empty.
-        // let last_delegation = self.delegations.last().unwrap();
-        // let prev_area = last_delegation.area();
-        // let prev_signature = last_delegation.signature();
+        // We can unwrap here because we know that self.delegations is not empty.
+        let last_delegation = self.cap.delegations.last().unwrap();
+        let prev_area = last_delegation.area();
+        let prev_signature = last_delegation.signature();
 
-        // // We can safely unwrap all these encodings as IntoVec's error is the never type.
-        // new_area.relative_encode(prev_area, &mut consumer).unwrap();
-        // prev_signature.encode(&mut consumer).unwrap();
-        // new_user.encode(&mut consumer).unwrap();
+        // We can safely unwrap all these encodings as IntoVec's error is the never type.
+        self.area.relative_encode(consumer, prev_area).await?;
+        prev_signature.encode(consumer).await?;
+        self.user.encode(consumer).await?;
 
-        // consumer.into_vec().into()
+        Ok(())
     }
+}
+
+impl<
+        'a,
+        const MCL: usize,
+        const MCC: usize,
+        const MPL: usize,
+        NamespacePublicKey,
+        UserPublicKey,
+        UserSignature,
+    > EncodableKnownSize
+    for CommunalHandover<'a, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
+where
+    NamespacePublicKey: NamespaceId + EncodableSync + EncodableKnownSize + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize,
+{
+    fn len_of_encoding(&self) -> usize {
+        if self.cap.delegations.is_empty() {
+            let prev_area =
+                Area::<MCL, MCC, MPL, UserPublicKey>::new_subspace(self.cap.user_key.clone());
+
+            let namespace_len = self.cap.namespace_key.len_of_encoding();
+            let area_len = self.area.relative_len_of_encoding(&prev_area);
+            let user_len = self.user.len_of_encoding();
+
+            return 1 + namespace_len + area_len + user_len;
+        }
+
+        // We can unwrap here because we know that self.delegations is not empty.
+        let last_delegation = self.cap.delegations.last().unwrap();
+        let prev_area = last_delegation.area();
+        let prev_signature = last_delegation.signature();
+
+        let area_len = self.area.relative_len_of_encoding(prev_area);
+        let sig_len = prev_signature.len_of_encoding();
+        let user_len = self.user.len_of_encoding();
+
+        area_len + sig_len + user_len
+    }
+}
+
+impl<
+        'a,
+        const MCL: usize,
+        const MCC: usize,
+        const MPL: usize,
+        NamespacePublicKey,
+        UserPublicKey,
+        UserSignature,
+    > EncodableSync
+    for CommunalHandover<'a, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
+where
+    NamespacePublicKey: NamespaceId + EncodableSync + EncodableKnownSize + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize,
+{
 }
 
 #[cfg(feature = "dev")]
@@ -279,9 +381,11 @@ impl<
     > Arbitrary<'a>
     for CommunalCapability<MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
 where
-    NamespacePublicKey: NamespaceId + Encodable + IsCommunal + Arbitrary<'a>,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature> + Arbitrary<'a>,
-    UserSignature: Encodable + Clone,
+    NamespacePublicKey:
+        NamespaceId + EncodableSync + EncodableKnownSize + IsCommunal + Arbitrary<'a>,
+    UserPublicKey:
+        SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature> + Arbitrary<'a>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let namespace_key: NamespacePublicKey = Arbitrary::arbitrary(u)?;

--- a/meadowcap/src/mc_authorisation_token.rs
+++ b/meadowcap/src/mc_authorisation_token.rs
@@ -1,5 +1,5 @@
 use signature::Verifier;
-use ufotofu_codec::Encodable;
+use ufotofu_codec::{Encodable, EncodableKnownSize, EncodableSync};
 use willow_data_model::{AuthorisationToken, Entry, NamespaceId, PayloadDigest, SubspaceId};
 
 use crate::{mc_capability::McCapability, AccessMode, IsCommunal};
@@ -17,10 +17,14 @@ pub struct McAuthorisationToken<
     UserPublicKey,
     UserSignature,
 > where
-    NamespacePublicKey: NamespaceId + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + Clone,
-    UserSignature: Encodable + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     /// Certifies that an Entry may be written.
     pub capability: McCapability<
@@ -55,10 +59,14 @@ impl<
         UserSignature,
     >
 where
-    NamespacePublicKey: NamespaceId + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + Clone,
-    UserSignature: Encodable + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     /// Returns a new [`McAuthorisationToken`] using the given [`McCapability`] and [`UserSignature`].
     ///
@@ -102,11 +110,15 @@ impl<
         UserSignature,
     >
 where
-    NamespacePublicKey: NamespaceId + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + Clone,
-    UserSignature: Encodable + Clone,
-    PD: PayloadDigest + Encodable,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
+    PD: PayloadDigest + EncodableSync + EncodableKnownSize,
 {
     fn is_authorised_write(
         &self,
@@ -163,11 +175,16 @@ impl<
         UserSignature,
     >
 where
-    NamespacePublicKey:
-        NamespaceId + Encodable + IsCommunal + Arbitrary<'a> + Verifier<NamespaceSignature>,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature> + Arbitrary<'a>,
-    NamespaceSignature: Encodable + Clone + Arbitrary<'a>,
-    UserSignature: Encodable + Clone + Arbitrary<'a>,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + IsCommunal
+        + Arbitrary<'a>
+        + Verifier<NamespaceSignature>,
+    UserPublicKey:
+        SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature> + Arbitrary<'a>,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone + Arbitrary<'a>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone + Arbitrary<'a>,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let capability: McCapability<

--- a/meadowcap/src/mc_authorisation_token.rs
+++ b/meadowcap/src/mc_authorisation_token.rs
@@ -133,21 +133,18 @@ where
             return false;
         }
 
-        todo!("Implement with a single allocation with known-size encoder trait.")
+        let message = entry.sync_encode_into_boxed_slice();
 
-        // let mut consumer = IntoVec::<u8>::new();
-        // entry.encode(&mut consumer).unwrap();
+        if self
+            .capability
+            .receiver()
+            .verify(&message, &self.signature)
+            .is_err()
+        {
+            return false;
+        }
 
-        // if self
-        //     .capability
-        //     .receiver()
-        //     .verify(&consumer.into_vec(), &self.signature)
-        //     .is_err()
-        // {
-        //     return false;
-        // }
-
-        // true
+        true
     }
 }
 

--- a/meadowcap/src/mc_capability.rs
+++ b/meadowcap/src/mc_capability.rs
@@ -1,12 +1,14 @@
 #[cfg(feature = "dev")]
 use arbitrary::Arbitrary;
+use compact_u64::{CompactU64, Tag, TagWidth};
 use either::Either;
 use signature::{Error as SignatureError, Signer, Verifier};
 use ufotofu_codec::{
-    Blame, DecodableCanonic, Encodable, RelativeDecodable, RelativeDecodableCanonic,
-    RelativeEncodable, RelativeEncodableKnownSize,
+    Blame, DecodableCanonic, DecodeError, Encodable, EncodableKnownSize, EncodableSync,
+    RelativeDecodable, RelativeDecodableCanonic, RelativeEncodable, RelativeEncodableKnownSize,
 };
 use willow_data_model::{grouping::Area, Entry, NamespaceId, PayloadDigest, SubspaceId};
+use willow_encoding::is_bitflagged;
 
 use crate::{
     communal_capability::{CommunalCapability, NamespaceIsNotCommunalError},
@@ -44,10 +46,14 @@ pub enum McCapability<
     UserPublicKey,
     UserSignature,
 > where
-    NamespacePublicKey: NamespaceId + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + Clone,
-    UserSignature: Encodable + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     Communal(CommunalCapability<MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>),
     Owned(
@@ -82,10 +88,14 @@ impl<
         UserSignature,
     >
 where
-    NamespacePublicKey: NamespaceId + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + Clone,
-    UserSignature: Encodable + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     /// Creates a new communal capability granting access to the [`SubspaceId`] corresponding to the given `UserPublicKey`, or return an error if the namespace key is not communal.
     pub fn new_communal(
@@ -232,21 +242,19 @@ where
     >
     where
         UserSecret: Signer<UserSignature>,
-        PD: PayloadDigest + Encodable,
+        PD: PayloadDigest + EncodableSync + EncodableKnownSize,
     {
         match self.access_mode() {
             AccessMode::Read => Err(NotAWriteCapabilityError),
             AccessMode::Write => {
-                todo!("Implement with a single allocation with known-size encoder trait.")
-                // let mut consumer = IntoVec::<u8>::new();
-                // entry.encode(&mut consumer).unwrap();
+                let entry_enc = entry.sync_encode_into_boxed_slice();
 
-                // let signature = secret.sign(&consumer.into_vec());
+                let signature = secret.sign(&entry_enc);
 
-                // Ok(McAuthorisationToken {
-                //     capability: self.clone(),
-                //     signature,
-                // })
+                Ok(McAuthorisationToken {
+                    capability: self.clone(),
+                    signature,
+                })
             }
         }
     }
@@ -270,27 +278,23 @@ where
     >
     where
         UserSecret: Signer<UserSignature>,
-        PD: PayloadDigest + Encodable,
+        PD: PayloadDigest + EncodableSync + EncodableKnownSize,
     {
         match self.access_mode() {
             AccessMode::Read => Err(Either::Left(NotAWriteCapabilityError)),
             AccessMode::Write => {
-                todo!("Implement with a single allocation with known-size encoder trait.")
-                // let mut consumer = IntoVec::<u8>::new();
-                // entry.encode(&mut consumer).unwrap();
+                let message = entry.sync_encode_into_boxed_slice();
 
-                // let message = consumer.into_vec();
+                let signature = secret.sign(&message);
 
-                // let signature = secret.sign(&message);
+                self.receiver()
+                    .verify(&message, &signature)
+                    .map_err(Either::Right)?;
 
-                // self.receiver()
-                //     .verify(&message, &signature)
-                //     .map_err(Either::Right)?;
-
-                // Ok(McAuthorisationToken {
-                //     capability: self.clone(),
-                //     signature,
-                // })
+                Ok(McAuthorisationToken {
+                    capability: self.clone(),
+                    signature,
+                })
             }
         }
     }
@@ -315,11 +319,15 @@ impl<
         UserSignature,
     >
 where
-    NamespacePublicKey:
-        NamespaceId + Encodable + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Encodable + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + Encodable + Clone,
-    UserSignature: Encodable + Encodable + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey:
+        SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature> + std::fmt::Debug,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     async fn relative_encode<C>(
         &self,
@@ -329,7 +337,10 @@ where
     where
         C: ufotofu::BulkConsumer<Item = u8>,
     {
-        /*
+        if !r.includes_area(&self.granted_area()) {
+            panic!("Tried to encode a McCapability relative to an area its own granted area is not included by.")
+        }
+
         let mut header: u8 = 0;
 
         match self {
@@ -349,16 +360,12 @@ where
 
         let delegations_count = self.delegations_len() as u64;
 
-        if delegations_count >= 4294967296 {
-            header |= 0b0011_1111;
-        } else if delegations_count >= 65536 {
-            header |= 0b0011_1110;
-        } else if delegations_count >= 256 {
-            header |= 0b0011_1101;
-        } else if delegations_count >= 60 {
-            header |= 0b0011_1100;
-        } else {
+        if delegations_count < 60 {
             header |= delegations_count as u8;
+        } else {
+            let tag = Tag::min_tag(delegations_count, TagWidth::two());
+            header |= 0b0011_1100;
+            header |= tag.data();
         }
 
         consumer.consume(header).await?;
@@ -374,15 +381,19 @@ where
         };
 
         if delegations_count >= 60 {
-            encode_compact_width_be(delegations_count, consumer).await?;
+            let tag = Tag::min_tag(delegations_count, TagWidth::two());
+
+            CompactU64(delegations_count)
+                .relative_encode(consumer, &tag.encoding_width())
+                .await?;
         }
 
-        let mut prev_area = out.clone();
+        let mut prev_area = r.clone();
 
         for delegation in self.delegations() {
             delegation
                 .area
-                .relative_encode(&prev_area, consumer)
+                .relative_encode(consumer, &prev_area)
                 .await?;
             prev_area = delegation.area.clone();
             Encodable::encode(&delegation.user, consumer).await?;
@@ -390,8 +401,6 @@ where
         }
 
         Ok(())
-        */
-        todo!()
     }
 }
 
@@ -414,11 +423,28 @@ impl<
         UserSignature,
     >
 where
-    NamespacePublicKey:
-        NamespaceId + Encodable + DecodableCanonic + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + DecodableCanonic + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + DecodableCanonic + Clone,
-    UserSignature: Encodable + DecodableCanonic + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + DecodableCanonic
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey: SubspaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + DecodableCanonic
+        + Verifier<UserSignature>
+        + std::fmt::Debug,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + DecodableCanonic + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + DecodableCanonic + Clone,
+    Blame: From<NamespacePublicKey::ErrorReason>
+        + From<UserPublicKey::ErrorReason>
+        + From<NamespaceSignature::ErrorReason>
+        + From<UserSignature::ErrorReason>
+        + From<NamespacePublicKey::ErrorCanonic>
+        + From<UserPublicKey::ErrorCanonic>
+        + From<NamespaceSignature::ErrorCanonic>
+        + From<UserSignature::ErrorCanonic>,
 {
     async fn relative_decode<P>(
         producer: &mut P,
@@ -428,7 +454,7 @@ where
         P: ufotofu::BulkProducer<Item = u8>,
         Self: Sized,
     {
-        todo!("We don't actually need this...")
+        Self::relative_decode_canonic(producer, r).await
     }
 }
 
@@ -451,11 +477,28 @@ impl<
         UserSignature,
     >
 where
-    NamespacePublicKey:
-        NamespaceId + Encodable + DecodableCanonic + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + DecodableCanonic + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + DecodableCanonic + Clone,
-    UserSignature: Encodable + DecodableCanonic + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + DecodableCanonic
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey: SubspaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + DecodableCanonic
+        + Verifier<UserSignature>
+        + std::fmt::Debug,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + DecodableCanonic + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + DecodableCanonic + Clone,
+    Blame: From<NamespacePublicKey::ErrorReason>
+        + From<UserPublicKey::ErrorReason>
+        + From<NamespaceSignature::ErrorReason>
+        + From<UserSignature::ErrorReason>
+        + From<NamespacePublicKey::ErrorCanonic>
+        + From<UserPublicKey::ErrorCanonic>
+        + From<NamespaceSignature::ErrorCanonic>
+        + From<UserSignature::ErrorCanonic>,
 {
     async fn relative_decode_canonic<P>(
         producer: &mut P,
@@ -465,8 +508,7 @@ where
         P: ufotofu::BulkProducer<Item = u8>,
         Self: Sized,
     {
-        /*
-        let header = produce_byte(producer).await?;
+        let header = producer.produce_item().await?;
 
         let is_owned = is_bitflagged(header, 0);
         let access_mode = if is_bitflagged(header, 1) {
@@ -475,11 +517,21 @@ where
             AccessMode::Read
         };
 
-        let namespace_key = NamespacePublicKey::decode_canonical(producer).await?;
-        let user_key = UserPublicKey::decode_canonical(producer).await?;
+        let namespace_key = NamespacePublicKey::decode_canonic(producer)
+            .await
+            .map_err(DecodeError::map_other_from)?;
+        let user_key = UserPublicKey::decode_canonic(producer)
+            .await
+            .map_err(DecodeError::map_other_from)?;
+
+        if !r.subspace().includes(&user_key) {
+            return Err(DecodeError::Other(Blame::TheirFault));
+        }
 
         let mut base_cap = if is_owned {
-            let initial_authorisation = NamespaceSignature::decode_canonical(producer).await?;
+            let initial_authorisation = NamespaceSignature::decode_canonic(producer)
+                .await
+                .map_err(DecodeError::map_other_from)?;
 
             let cap = OwnedCapability::from_existing(
                 namespace_key,
@@ -487,43 +539,45 @@ where
                 initial_authorisation,
                 access_mode,
             )
-            .map_err(|_| DecodeError::InvalidInput)?;
+            .map_err(|_| DecodeError::Other(Blame::TheirFault))?;
 
             Self::Owned(cap)
         } else {
             let cap = CommunalCapability::new(namespace_key, user_key, access_mode)
-                .map_err(|_| DecodeError::InvalidInput)?;
+                .map_err(|_| DecodeError::Other(Blame::TheirFault))?;
 
             Self::Communal(cap)
         };
 
-        let delegations_to_decode = if header & 0b0011_1111 == 0b0011_1111 {
-            decode_compact_width_be(CompactWidth::Eight, producer).await?
-        } else if header & 0b0011_1110 == 0b0011_1110 {
-            decode_compact_width_be(CompactWidth::Four, producer).await?
-        } else if header & 0b0011_1101 == 0b0011_1101 {
-            decode_compact_width_be(CompactWidth::Two, producer).await?
-        } else if header & 0b0011_1100 == 0b0011_1100 {
-            decode_compact_width_be(CompactWidth::One, producer).await?
-        } else {
+        let delegations_to_decode = if (header & 0b0011_1111) < 60 {
             (header & 0b0011_1111) as u64
+        } else {
+            let tag = Tag::from_raw(header, TagWidth::two(), 6);
+
+            CompactU64::relative_decode_canonic(producer, &tag)
+                .await
+                .map_err(DecodeError::map_other_from)?
+                .0
         };
 
         if header & 0b0011_1100 == 0b0011_1100 && delegations_to_decode < 60 {
             // The delegation count should have been encoded directly in the header.
-            return Err(DecodeError::InvalidInput);
+            return Err(DecodeError::Other(Blame::TheirFault));
         }
 
-        let mut prev_area = out.clone();
+        let mut prev_area = r.clone();
 
         for _ in 0..delegations_to_decode {
-            let area = Area::<MCL, MCC, MPL, UserPublicKey>::relative_decode_canonical(
-                &prev_area, producer,
-            )
-            .await?;
+            let area =
+                Area::<MCL, MCC, MPL, UserPublicKey>::relative_decode_canonic(producer, &prev_area)
+                    .await?;
             prev_area = area.clone();
-            let user = UserPublicKey::decode_canonical(producer).await?;
-            let signature = UserSignature::decode_canonical(producer).await?;
+            let user = UserPublicKey::decode_canonic(producer)
+                .await
+                .map_err(DecodeError::map_other_from)?;
+            let signature = UserSignature::decode_canonic(producer)
+                .await
+                .map_err(DecodeError::map_other_from)?;
 
             base_cap
                 .append_existing_delegation(Delegation {
@@ -531,13 +585,10 @@ where
                     user,
                     signature,
                 })
-                .map_err(|_| DecodeError::InvalidInput)?;
+                .map_err(|_| DecodeError::Other(Blame::TheirFault))?;
         }
 
         Ok(base_cap)
-        */
-
-        todo!()
     }
 }
 
@@ -560,13 +611,48 @@ impl<
         UserSignature,
     >
 where
-    NamespacePublicKey:
-        NamespaceId + Encodable + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    UserPublicKey: SubspaceId + Encodable + Encodable + Verifier<UserSignature>,
-    NamespaceSignature: Encodable + Encodable + Clone,
-    UserSignature: Encodable + Encodable + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    UserPublicKey:
+        SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature> + std::fmt::Debug,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     fn relative_len_of_encoding(&self, r: &Area<MCL, MCC, MPL, UserPublicKey>) -> usize {
-        todo!()
+        let namespace_len = self.granted_namespace().len_of_encoding();
+        let progenitor_len = self.progenitor().len_of_encoding();
+
+        let init_auth_len = match self {
+            McCapability::Communal(_) => 0,
+            McCapability::Owned(cap) => cap.initial_authorisation().len_of_encoding(),
+        };
+
+        let delegations_count = self.delegations_len() as u64;
+
+        let delegations_count_len = if delegations_count >= 60 {
+            let tag = Tag::min_tag(delegations_count, TagWidth::two());
+
+            CompactU64(delegations_count).relative_len_of_encoding(&tag.encoding_width())
+        } else {
+            0
+        };
+
+        let mut prev_area = r.clone();
+
+        let mut delegations_len = 0;
+
+        for delegation in self.delegations() {
+            delegations_len += delegation.area.relative_len_of_encoding(&prev_area);
+
+            prev_area = delegation.area.clone();
+
+            delegations_len += delegation.user.len_of_encoding();
+            delegations_len += delegation.signature().len_of_encoding();
+        }
+
+        1 + namespace_len + progenitor_len + init_auth_len + delegations_count_len + delegations_len
     }
 }

--- a/meadowcap/src/mc_subspace_capability.rs
+++ b/meadowcap/src/mc_subspace_capability.rs
@@ -1,10 +1,18 @@
+use compact_u64::CompactU64;
+use compact_u64::Tag;
+use compact_u64::TagWidth;
 use signature::{Error as SignatureError, Signer, Verifier};
 use ufotofu::Consumer;
 use ufotofu_codec::Blame;
 use ufotofu_codec::Decodable;
 use ufotofu_codec::DecodableCanonic;
+use ufotofu_codec::DecodeError;
 use ufotofu_codec::Encodable;
 use ufotofu_codec::EncodableKnownSize;
+use ufotofu_codec::EncodableSync;
+use ufotofu_codec::RelativeDecodableCanonic;
+use ufotofu_codec::RelativeEncodable;
+use ufotofu_codec::RelativeEncodableKnownSize;
 use willow_data_model::NamespaceId;
 use willow_data_model::SubspaceId;
 
@@ -67,10 +75,14 @@ pub struct McSubspaceCapability<
 impl<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
     McSubspaceCapability<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
 where
-    NamespacePublicKey: NamespaceId + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    NamespaceSignature: Encodable + Clone,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature>,
-    UserSignature: Encodable + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
 {
     /// Creates a new [`McSubspaceCapability`] for a given user, or return an error if the given namespace secret is incorrect.
     pub fn new<NamespaceSecret>(
@@ -84,24 +96,20 @@ where
     where
         NamespaceSecret: Signer<NamespaceSignature>,
     {
-        todo!("Implement with a single allocation with known-size encoder trait.")
-        // let mut consumer = IntoVec::<u8>::new();
+        let init_auth = SubspaceInitialAuthorisationMsg(&user_key);
 
-        // // We can unwrap here because IntoVec::Error is ! (never)
-        // consumer.consume(0x2).unwrap();
-        // user_key.encode(&mut consumer).unwrap();
-        // let message = consumer.into_vec();
+        let message = init_auth.sync_encode_into_boxed_slice();
 
-        // let signature = namespace_secret.sign(&message);
+        let signature = namespace_secret.sign(&message);
 
-        // namespace_key.verify(&message, &signature)?;
+        namespace_key.verify(&message, &signature)?;
 
-        // Ok(McSubspaceCapability {
-        //     namespace_key: namespace_key.clone(),
-        //     user_key,
-        //     initial_authorisation: signature,
-        //     delegations: Vec::new(),
-        // })
+        Ok(McSubspaceCapability {
+            namespace_key: namespace_key.clone(),
+            user_key,
+            initial_authorisation: signature,
+            delegations: Vec::new(),
+        })
     }
 
     /// Creates an [`McSubspaceCapability`] using an existing authorisation (e.g. one received over the network), or return an error if the signature was not created by the namespace key.
@@ -110,22 +118,17 @@ where
         user_key: UserPublicKey,
         initial_authorisation: NamespaceSignature,
     ) -> Result<Self, SignatureError> {
-        todo!("Implement with a single allocation with known-size encoder trait.")
-        // let mut consumer = IntoVec::<u8>::new();
+        let init_auth = SubspaceInitialAuthorisationMsg(&user_key);
 
-        // // We can unwrap here because IntoVec::Error is ! (never)
-        // consumer.consume(0x2).unwrap();
-        // user_key.encode(&mut consumer).unwrap();
-        // let message = consumer.into_vec();
+        let message = init_auth.sync_encode_into_boxed_slice();
 
-        // namespace_key.verify(&message, &initial_authorisation)?;
-
-        // Ok(Self {
-        //     namespace_key,
-        //     user_key,
-        //     initial_authorisation,
-        //     delegations: Vec::new(),
-        // })
+        namespace_key.verify(&message, &initial_authorisation)?;
+        Ok(Self {
+            namespace_key,
+            user_key,
+            initial_authorisation,
+            delegations: Vec::new(),
+        })
     }
 
     /// Returns the public key of the user to whom this capability grants access.
@@ -160,10 +163,16 @@ where
     {
         let prev_user = self.receiver();
 
-        let handover = self.handover(new_user);
-        let signature = secret_key.sign(&handover);
+        let handover = SubspaceHandover {
+            subspace_cap: self,
+            user: new_user,
+        };
 
-        prev_user.verify(&handover, &signature)?;
+        let handover_enc = handover.sync_encode_into_boxed_slice();
+
+        let signature = secret_key.sign(&handover_enc);
+
+        prev_user.verify(&handover_enc, &signature)?;
 
         let mut new_delegations = self.delegations.clone();
 
@@ -185,11 +194,16 @@ where
         let new_user = &delegation.user();
         let new_sig = &delegation.signature();
 
-        let handover = self.handover(new_user);
+        let handover = SubspaceHandover {
+            subspace_cap: self,
+            user: new_user,
+        };
+
+        let handover_enc = handover.sync_encode_into_boxed_slice();
 
         let prev_receiver = self.receiver();
 
-        prev_receiver.verify(&handover, new_sig)?;
+        prev_receiver.verify(&handover_enc, new_sig)?;
 
         self.delegations.push(delegation);
 
@@ -201,33 +215,6 @@ where
         &self,
     ) -> impl Iterator<Item = &SubspaceDelegation<UserPublicKey, UserSignature>> {
         self.delegations.iter()
-    }
-
-    /// Returns a bytestring to be signed for a new subspace capability delegation.
-    ///
-    /// [Definition](https://willowprotocol.org/specs/pai/index.html#subspace_handover)
-    fn handover(&self, new_user: &UserPublicKey) -> Box<[u8]> {
-        todo!("Implement with a single allocation with known-size encoder trait.")
-        // let mut consumer = IntoVec::<u8>::new();
-
-        // if self.delegations.is_empty() {
-        //     // We can safely unwrap all these encodings as IntoVec's error is the never type.
-
-        //     self.initial_authorisation.encode(&mut consumer).unwrap();
-        //     new_user.encode(&mut consumer).unwrap();
-
-        //     return consumer.into_vec().into();
-        // }
-
-        // // We can unwrap here because we know that self.delegations is not empty.
-        // let last_delegation = self.delegations.last().unwrap();
-
-        // let prev_signature = &last_delegation.signature();
-        // // We can safely unwrap all these encodings as IntoVec's error is the never type.
-        // prev_signature.encode(&mut consumer).unwrap();
-        // new_user.encode(&mut consumer).unwrap();
-
-        // consumer.into_vec().into()
     }
 }
 
@@ -244,21 +231,16 @@ where
     where
         C: ufotofu::BulkConsumer<Item = u8>,
     {
-        /*
         let mut header = 0;
 
         let delegations_count = self.delegations.len() as u64;
 
-        if delegations_count >= 4294967296 {
-            header |= 0b1111_1111;
-        } else if delegations_count >= 65536 {
-            header |= 0b1111_1110;
-        } else if delegations_count >= 256 {
-            header |= 0b1111_1101;
-        } else if delegations_count >= 60 {
-            header |= 0b1111_1100;
+        if delegations_count < 252 {
+            header |= delegations_count as u8
         } else {
-            header |= delegations_count as u8;
+            let tag = Tag::min_tag(delegations_count, TagWidth::two());
+            header |= 0b1111_1100;
+            header |= tag.data();
         }
 
         consumer.consume(header).await?;
@@ -267,8 +249,12 @@ where
         Encodable::encode(&self.user_key, consumer).await?;
         Encodable::encode(&self.initial_authorisation, consumer).await?;
 
-        if delegations_count >= 60 {
-            encode_compact_width_be(delegations_count, consumer).await?;
+        if delegations_count >= 252 {
+            let tag = Tag::min_tag(delegations_count, TagWidth::two());
+
+            CompactU64(delegations_count)
+                .relative_encode(consumer, &tag.encoding_width())
+                .await?;
         }
 
         for delegation in self.delegations.iter() {
@@ -277,20 +263,33 @@ where
         }
 
         Ok(())
-        */
-
-        todo!()
     }
 }
 
 impl<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature> Decodable
     for McSubspaceCapability<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
 where
-    NamespacePublicKey:
-        NamespaceId + Encodable + Decodable + Verifier<NamespaceSignature> + IsCommunal,
-    NamespaceSignature: Encodable + Decodable + Clone,
-    UserPublicKey: SubspaceId + Encodable + Decodable + Verifier<UserSignature>,
-    UserSignature: Encodable + Decodable + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + DecodableCanonic
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + DecodableCanonic + Clone,
+    UserPublicKey: SubspaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + DecodableCanonic
+        + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize + DecodableCanonic + Clone,
+    Blame: From<NamespacePublicKey::ErrorReason>
+        + From<UserPublicKey::ErrorReason>
+        + From<NamespaceSignature::ErrorReason>
+        + From<UserSignature::ErrorReason>
+        + From<NamespacePublicKey::ErrorCanonic>
+        + From<UserPublicKey::ErrorCanonic>
+        + From<NamespaceSignature::ErrorCanonic>
+        + From<UserSignature::ErrorCanonic>,
 {
     type ErrorReason = Blame;
 
@@ -301,18 +300,34 @@ where
         P: ufotofu::BulkProducer<Item = u8>,
         Self: Sized,
     {
-        todo!("We don't actually need this...")
+        Self::decode_canonic(producer).await
     }
 }
 
 impl<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature> DecodableCanonic
     for McSubspaceCapability<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
 where
-    NamespacePublicKey:
-        NamespaceId + Encodable + DecodableCanonic + Verifier<NamespaceSignature> + IsCommunal,
-    NamespaceSignature: Encodable + DecodableCanonic + Clone,
-    UserPublicKey: SubspaceId + Encodable + DecodableCanonic + Verifier<UserSignature>,
-    UserSignature: Encodable + DecodableCanonic + Clone,
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + DecodableCanonic
+        + Verifier<NamespaceSignature>
+        + IsCommunal,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + DecodableCanonic + Clone,
+    UserPublicKey: SubspaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + DecodableCanonic
+        + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize + DecodableCanonic + Clone,
+    Blame: From<NamespacePublicKey::ErrorReason>
+        + From<UserPublicKey::ErrorReason>
+        + From<NamespaceSignature::ErrorReason>
+        + From<UserSignature::ErrorReason>
+        + From<NamespacePublicKey::ErrorCanonic>
+        + From<UserPublicKey::ErrorCanonic>
+        + From<NamespaceSignature::ErrorCanonic>
+        + From<UserSignature::ErrorCanonic>,
 {
     type ErrorCanonic = Blame;
 
@@ -323,93 +338,68 @@ where
         P: ufotofu::BulkProducer<Item = u8>,
         Self: Sized,
     {
-        /*
-        // TODO: Strict encoding relations - this decoder will not throw if the number of delegations claimed is not the same as the number of delegations decoded.
+        let header = producer.produce_item().await?;
 
-        let header = produce_byte(producer).await?;
-
-        let namespace_key = NamespacePublicKey::decode_canonical(producer).await?;
-        let user_key = UserPublicKey::decode_canonical(producer).await?;
-        let initial_authorisation = NamespaceSignature::decode_canonical(producer).await?;
+        let namespace_key = NamespacePublicKey::decode_canonic(producer)
+            .await
+            .map_err(DecodeError::map_other_from)?;
+        let user_key = UserPublicKey::decode_canonic(producer)
+            .await
+            .map_err(DecodeError::map_other_from)?;
+        let initial_authorisation = NamespaceSignature::decode_canonic(producer)
+            .await
+            .map_err(DecodeError::map_other_from)?;
 
         let mut base_cap = Self::from_existing(namespace_key, user_key, initial_authorisation)
-            .map_err(|_| DecodeError::InvalidInput)?;
+            .map_err(|_| DecodeError::Other(Blame::TheirFault))?;
 
-        let delegations_to_decode = if header == 0b1111_1111 {
-            decode_compact_width_be(CompactWidth::Eight, producer).await?
-        } else if header == 0b1111_1110 {
-            decode_compact_width_be(CompactWidth::Four, producer).await?
-        } else if header == 0b1111_1101 {
-            decode_compact_width_be(CompactWidth::Two, producer).await?
-        } else if header == 0b1111_1100 {
-            let count = decode_compact_width_be(CompactWidth::One, producer).await?;
-
-            if count < 60 {
-                Err(DecodeError::InvalidInput)?;
-            }
-
-            count
+        let delegations_to_decode = if header < 252 {
+            header as u64
         } else {
-            let count = header as u64;
+            let tag = Tag::from_raw(header, TagWidth::two(), 6);
 
-            if count > 60 {
-                Err(DecodeError::InvalidInput)?;
+            let count = CompactU64::relative_decode_canonic(producer, &tag)
+                .await
+                .map_err(DecodeError::map_other_from)?
+                .0;
+
+            let expected_tag = Tag::min_tag(count, TagWidth::two());
+
+            if expected_tag != tag {
+                return Err(DecodeError::Other(Blame::TheirFault));
             }
 
             count
         };
 
+        if header & 0b1111_1100 == 0b1111_1100 && delegations_to_decode < 252 {
+            // The delegation count should have been encoded directly in the header.
+            return Err(DecodeError::Other(Blame::TheirFault));
+        }
+
+        let mut delegations_decoded = 0;
+
         for _ in 0..delegations_to_decode {
-            let user = UserPublicKey::decode_canonical(producer).await?;
-            let signature = UserSignature::decode_canonical(producer).await?;
+            let user = UserPublicKey::decode_canonic(producer)
+                .await
+                .map_err(DecodeError::map_other_from)?;
+            let signature = UserSignature::decode_canonic(producer)
+                .await
+                .map_err(DecodeError::map_other_from)?;
             let delegation = SubspaceDelegation::new(user, signature);
 
             base_cap
                 .append_existing_delegation(delegation)
-                .map_err(|_| DecodeError::InvalidInput)?;
+                .map_err(|_| DecodeError::Other(Blame::TheirFault))?;
+
+            delegations_decoded += 1;
+        }
+
+        if delegations_decoded != delegations_to_decode {
+            return Err(DecodeError::Other(Blame::TheirFault));
         }
 
         Ok(base_cap)
-        */
-
-        todo!()
-    }
-}
-
-#[cfg(feature = "dev")]
-impl<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature> Arbitrary<'a>
-    for McSubspaceCapability<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
-where
-    NamespacePublicKey:
-        NamespaceId + Encodable + IsCommunal + Arbitrary<'a> + Verifier<NamespaceSignature>,
-    UserPublicKey: SubspaceId + Encodable + Verifier<UserSignature> + Arbitrary<'a>,
-    NamespaceSignature: Encodable + Clone + Arbitrary<'a>,
-    UserSignature: Encodable + Clone,
-{
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let namespace_key: NamespacePublicKey = Arbitrary::arbitrary(u)?;
-        let user_key: UserPublicKey = Arbitrary::arbitrary(u)?;
-        let initial_authorisation: NamespaceSignature = Arbitrary::arbitrary(u)?;
-
-        todo!("Implement with a single allocation with known-size encoder trait.")
-
-        // let mut consumer = IntoVec::<u8>::new();
-
-        // // We can unwrap here because IntoVec::Error is ! (never)
-        // consumer.consume(0x2).unwrap();
-        // user_key.encode(&mut consumer).unwrap();
-        // let message = consumer.into_vec();
-
-        // namespace_key
-        //     .verify(&message, &initial_authorisation)
-        //     .map_err(|_| ArbitraryError::IncorrectFormat)?;
-
-        // Ok(Self {
-        //     namespace_key,
-        //     user_key,
-        //     initial_authorisation,
-        //     delegations: Vec::new(),
-        // })
     }
 }
 
@@ -417,12 +407,218 @@ impl<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature> Encod
     for McSubspaceCapability<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
 where
     NamespacePublicKey:
-        NamespaceId + Encodable + Encodable + Verifier<NamespaceSignature> + IsCommunal,
-    NamespaceSignature: Encodable + Encodable + Clone,
-    UserPublicKey: SubspaceId + Encodable + Encodable + Verifier<UserSignature>,
-    UserSignature: Encodable + Encodable + Clone,
+        NamespaceId + EncodableKnownSize + Verifier<NamespaceSignature> + IsCommunal,
+    NamespaceSignature: EncodableKnownSize + Clone,
+    UserPublicKey: SubspaceId + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableKnownSize + Clone,
 {
     fn len_of_encoding(&self) -> usize {
-        todo!()
+        let delegations_count = self.delegations.len() as u64;
+
+        let namespace_len = self.namespace_key.len_of_encoding();
+        let user_len = self.user_key.len_of_encoding();
+        let init_auth_len = self.initial_authorisation.len_of_encoding();
+
+        let delegation_count_len = if delegations_count >= 60 {
+            let tag = Tag::min_tag(delegations_count, TagWidth::two());
+
+            CompactU64(delegations_count).relative_len_of_encoding(&tag.encoding_width())
+        } else {
+            0
+        };
+
+        let mut delegations_len = 0;
+
+        for delegation in self.delegations.iter() {
+            delegations_len += delegation.user.len_of_encoding();
+            delegations_len += delegation.signature().len_of_encoding();
+        }
+
+        1 + namespace_len + user_len + init_auth_len + delegation_count_len + delegations_len
+    }
+}
+
+struct SubspaceInitialAuthorisationMsg<'a, UserPublicKey>(&'a UserPublicKey)
+where
+    UserPublicKey: EncodableSync + EncodableKnownSize;
+
+impl<'a, UserPublicKey> Encodable for SubspaceInitialAuthorisationMsg<'a, UserPublicKey>
+where
+    UserPublicKey: EncodableSync + EncodableKnownSize,
+{
+    async fn encode<C>(&self, consumer: &mut C) -> Result<(), C::Error>
+    where
+        C: ufotofu::BulkConsumer<Item = u8>,
+    {
+        consumer.consume(0x2).await?;
+        self.0.encode(consumer).await?;
+
+        Ok(())
+    }
+}
+
+impl<'a, UserPublicKey> EncodableKnownSize for SubspaceInitialAuthorisationMsg<'a, UserPublicKey>
+where
+    UserPublicKey: EncodableSync + EncodableKnownSize,
+{
+    fn len_of_encoding(&self) -> usize {
+        1 + self.0.len_of_encoding()
+    }
+}
+
+impl<'a, UserPublicKey> EncodableSync for SubspaceInitialAuthorisationMsg<'a, UserPublicKey> where
+    UserPublicKey: EncodableSync + EncodableKnownSize
+{
+}
+
+/// Can be encoded to a bytestring to be signed for a new subspace capability delegation.
+///
+/// [Definition](https://willowprotocol.org/specs/pai/index.html#subspace_handover)
+struct SubspaceHandover<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
+where
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal
+        + Clone,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
+{
+    subspace_cap: &'a McSubspaceCapability<
+        NamespacePublicKey,
+        NamespaceSignature,
+        UserPublicKey,
+        UserSignature,
+    >,
+    user: &'a UserPublicKey,
+}
+
+impl<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature> Encodable
+    for SubspaceHandover<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
+where
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal
+        + Clone,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
+{
+    async fn encode<C>(&self, consumer: &mut C) -> Result<(), C::Error>
+    where
+        C: ufotofu::BulkConsumer<Item = u8>,
+    {
+        if self.subspace_cap.delegations.is_empty() {
+            // We can safely unwrap all these encodings as IntoVec's error is the never type.
+
+            self.subspace_cap
+                .initial_authorisation
+                .encode(consumer)
+                .await?;
+            self.user.encode(consumer).await?;
+
+            return Ok(());
+        }
+
+        // We can unwrap here because we know that self.delegations is not empty.
+        let last_delegation = self.subspace_cap.delegations.last().unwrap();
+
+        let prev_signature = &last_delegation.signature();
+        // We can safely unwrap all these encodings as IntoVec's error is the never type.
+        prev_signature.encode(consumer).await?;
+        self.user.encode(consumer).await?;
+
+        Ok(())
+    }
+}
+
+impl<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature> EncodableKnownSize
+    for SubspaceHandover<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
+where
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal
+        + Clone,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
+{
+    fn len_of_encoding(&self) -> usize {
+        if self.subspace_cap.delegations.is_empty() {
+            // We can safely unwrap all these encodings as IntoVec's error is the never type.
+
+            let init_auth_len = self.subspace_cap.initial_authorisation.len_of_encoding();
+            let user_len = self.user.len_of_encoding();
+
+            return init_auth_len + user_len;
+        }
+
+        // We can unwrap here because we know that self.delegations is not empty.
+        let last_delegation = self.subspace_cap.delegations.last().unwrap();
+
+        let prev_signature = &last_delegation.signature();
+        // We can safely unwrap all these encodings as IntoVec's error is the never type.
+
+        let prev_sig_len = prev_signature.len_of_encoding();
+        let user_len = self.user.len_of_encoding();
+
+        prev_sig_len + user_len
+    }
+}
+
+impl<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature> EncodableSync
+    for SubspaceHandover<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
+where
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + Verifier<NamespaceSignature>
+        + IsCommunal
+        + Clone,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone,
+    UserPublicKey: SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
+{
+}
+
+#[cfg(feature = "dev")]
+impl<'a, NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature> Arbitrary<'a>
+    for McSubspaceCapability<NamespacePublicKey, NamespaceSignature, UserPublicKey, UserSignature>
+where
+    NamespacePublicKey: NamespaceId
+        + EncodableSync
+        + EncodableKnownSize
+        + IsCommunal
+        + Arbitrary<'a>
+        + Verifier<NamespaceSignature>,
+    UserPublicKey:
+        SubspaceId + EncodableSync + EncodableKnownSize + Verifier<UserSignature> + Arbitrary<'a>,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone + Arbitrary<'a>,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let namespace_key: NamespacePublicKey = Arbitrary::arbitrary(u)?;
+        let user_key: UserPublicKey = Arbitrary::arbitrary(u)?;
+        let initial_authorisation: NamespaceSignature = Arbitrary::arbitrary(u)?;
+
+        let init_auth = SubspaceInitialAuthorisationMsg(&user_key);
+        let message = init_auth.sync_encode_into_boxed_slice();
+
+        namespace_key
+            .verify(&message, &initial_authorisation)
+            .map_err(|_| ArbitraryError::IncorrectFormat)?;
+
+        Ok(McSubspaceCapability {
+            namespace_key: namespace_key.clone(),
+            user_key,
+            initial_authorisation,
+            delegations: Vec::new(),
+        })
     }
 }

--- a/ufotofu_codec/src/proptest.rs
+++ b/ufotofu_codec/src/proptest.rs
@@ -353,9 +353,9 @@ macro_rules! fuzz_relative_all {
                         yield_pattern2,
                     )
                     .await;
-    
+
                     assert_relative_known_size_invariants(&r, &t1).await;
-    
+
                     assert_relative_canonic_invariants::<$t, $r, $errR, $errC>(
                         &r,
                         &potential_encoding1,
@@ -435,7 +435,7 @@ macro_rules! fuzz_relative_canonic {
                         yield_pattern2,
                     )
                     .await;
-    
+
                     assert_relative_canonic_invariants::<$t, $r, $errR, $errC>(
                         &r,
                         &potential_encoding1,
@@ -513,7 +513,7 @@ macro_rules! fuzz_relative_known_size {
                         yield_pattern2,
                     )
                     .await;
-    
+
                     assert_relative_known_size_invariants(&r, &t1).await;
                 });
             }

--- a/ufotofu_codec/src/proptest/relative.rs
+++ b/ufotofu_codec/src/proptest/relative.rs
@@ -5,7 +5,7 @@ use crate::{
 use core::fmt::Debug;
 use core::num::NonZeroUsize;
 use std::boxed::Box;
-use std::format;
+use std::{format, println};
 use ufotofu::producer::{FromSlice, TestProducerBuilder};
 use ufotofu::{consumer::TestConsumer, producer::TestProducer};
 
@@ -309,10 +309,12 @@ pub async fn assert_relative_canonic_invariants<T, R, ErrR, ErrC>(
         &potential_encoding2,
     )
     .await;
+
     assert_relative_canonic_decoding_specialises_regular_decoding::<T, R, ErrR, ErrC>(
         r,
         &potential_encoding1,
     )
     .await;
+
     assert_relative_canonic_decoding_roundtrips::<T, R, ErrR, ErrC>(r, &potential_encoding1).await;
 }


### PR DESCRIPTION
Implements all the todos we had in Meadowcap after the move to ufotofu_codec. Now all encoding operations (e.g. for creating messages to sign) happen in single allocations.