### PR TITLE
Event subscriptions in StoreSimpleSled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,9 +767,9 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "ufotofu"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2845753e6c45255b4c4b7b76e2a036a5fd2632e168c290f8b0af5fceef5f4f40"
+checksum = "b4f97ce440ea4dd2ce8acb0adb327ba0e80cc1d5aa6ed81b941721418d1bc62f"
 dependencies = [
  "arbitrary",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "ufotofu_queues"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d903d5bc0e14d24559dac3b9690d004ad3fb08d66f93d87d28f5cb3466b5b55b"
+checksum = "9abd2f0123cc71fa3adf9329b85d9eb863874e489744803f3a41fff59b56968d"
 
 [[package]]
 name = "unicode-ident"
@@ -891,6 +891,8 @@ dependencies = [
  "ufotofu",
  "ufotofu_codec",
  "ufotofu_codec_endian",
+ "ufotofu_queues",
+ "wb_async_utils",
  "willow-data-model",
 ]
 

--- a/data-model/src/grouping/area.rs
+++ b/data-model/src/grouping/area.rs
@@ -1,9 +1,8 @@
 #[cfg(feature = "dev")]
-use arbitrary::{size_hint::and_all, Arbitrary};
+use arbitrary::Arbitrary;
 
 use crate::{
     entry::{Entry, Timestamp},
-    parameters::{NamespaceId, PayloadDigest, SubspaceId},
     path::Path,
 };
 
@@ -11,14 +10,25 @@ use super::range::Range;
 
 /// The possible values of an [`Area`]'s `subspace`.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
-pub enum AreaSubspace<S: SubspaceId> {
+#[cfg_attr(feature = "dev", derive(Arbitrary))]
+pub enum AreaSubspace<S> {
     /// A value that signals that an [`Area`] includes Entries with arbitrary subspace_ids.
     Any,
     /// A concrete [`SubspaceId`].
     Id(S),
 }
 
-impl<S: SubspaceId> AreaSubspace<S> {
+impl<S> AreaSubspace<S> {
+    /// Returns whether this [`AreaSubspace`] includes Entries with arbitrary subspace_ids.
+    pub fn is_any(&self) -> bool {
+        matches!(self, AreaSubspace::Any)
+    }
+}
+
+impl<S> AreaSubspace<S>
+where
+    S: PartialEq,
+{
     /// Returns whether this [`AreaSubspace`] includes a given [`SubspaceId`].
     pub fn includes(&self, sub: &S) -> bool {
         match self {
@@ -26,7 +36,12 @@ impl<S: SubspaceId> AreaSubspace<S> {
             AreaSubspace::Id(id) => sub == id,
         }
     }
+}
 
+impl<S> AreaSubspace<S>
+where
+    S: PartialEq + Clone,
+{
     /// Returns the intersection between two [`AreaSubspace`].
     fn intersection(&self, other: &Self) -> Option<Self> {
         match (self, other) {
@@ -37,14 +52,9 @@ impl<S: SubspaceId> AreaSubspace<S> {
             (Self::Id(_a), Self::Id(_b)) => None,
         }
     }
-
-    /// Returns whether this [`AreaSubspace`] includes Entries with arbitrary subspace_ids.
-    pub fn is_any(&self) -> bool {
-        matches!(self, AreaSubspace::Any)
-    }
 }
 
-impl<S: SubspaceId> PartialEq<S> for AreaSubspace<S> {
+impl<S: PartialEq> PartialEq<S> for AreaSubspace<S> {
     fn eq(&self, other: &S) -> bool {
         match self {
             AreaSubspace::Any => false,
@@ -53,28 +63,12 @@ impl<S: SubspaceId> PartialEq<S> for AreaSubspace<S> {
     }
 }
 
-#[cfg(feature = "dev")]
-impl<'a, S> Arbitrary<'a> for AreaSubspace<S>
-where
-    S: SubspaceId + Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let is_any: bool = Arbitrary::arbitrary(u)?;
-
-        if !is_any {
-            let subspace: S = Arbitrary::arbitrary(u)?;
-
-            return Ok(Self::Id(subspace));
-        }
-
-        Ok(Self::Any)
-    }
-}
-
 /// A grouping of entries.
+///
 /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#areas).
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
-pub struct Area<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> {
+#[cfg_attr(feature = "dev", derive(Arbitrary))]
+pub struct Area<const MCL: usize, const MCC: usize, const MPL: usize, S> {
     /// To be included in this [`Area`], an [`Entry`]’s `subspace_id` must be equal to the subspace_id, unless it is any.
     subspace: AreaSubspace<S>,
     /// To be included in this [`Area`], an [`Entry`]’s `path` must be prefixed by the path.
@@ -83,7 +77,7 @@ pub struct Area<const MCL: usize, const MCC: usize, const MPL: usize, S: Subspac
     times: Range<Timestamp>,
 }
 
-impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> Area<MCL, MCC, MPL, S> {
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> Area<MCL, MCC, MPL, S> {
     /// Creates a new [`Area`].
     pub fn new(
         subspace: AreaSubspace<S>,
@@ -129,7 +123,7 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> Area<M
         }
     }
 
-    /// Returns an [`Area`] which includes all entries within a [subspace](https://willowprotocol.org/specs/data-model/index.html#subspace).
+    /// Returns an [`Area`] which includes all entries within a given [subspace](https://willowprotocol.org/specs/data-model/index.html#subspace).
     ///
     /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#subspace_area).
     pub fn new_subspace(sub: S) -> Self {
@@ -139,12 +133,14 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> Area<M
             times: Range::new_open(0),
         }
     }
+}
 
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> Area<MCL, MCC, MPL, S>
+where
+    S: PartialEq,
+{
     /// Returns whether an [`Area`] [includes](https://willowprotocol.org/specs/grouping-entries/index.html#area_include) an [`Entry`].
-    pub fn includes_entry<N: NamespaceId, PD: PayloadDigest>(
-        &self,
-        entry: &Entry<MCL, MCC, MPL, N, S, PD>,
-    ) -> bool {
+    pub fn includes_entry<N, PD>(&self, entry: &Entry<MCL, MCC, MPL, N, S, PD>) -> bool {
         self.includes_triplet(entry.subspace_id(), entry.path(), entry.timestamp())
     }
 
@@ -177,7 +173,12 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> Area<M
             }
         }
     }
+}
 
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> Area<MCL, MCC, MPL, S>
+where
+    S: PartialEq + Clone,
+{
     /// Returns the intersection of this [`Area`] with another.
     ///
     /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#area_intersection).
@@ -199,33 +200,6 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> Area<M
     }
 }
 
-#[cfg(feature = "dev")]
-impl<'a, const MCL: usize, const MCC: usize, const MPL: usize, S> Arbitrary<'a>
-    for Area<MCL, MCC, MPL, S>
-where
-    S: SubspaceId + Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let subspace: AreaSubspace<S> = Arbitrary::arbitrary(u)?;
-        let path: Path<MCL, MCC, MPL> = Arbitrary::arbitrary(u)?;
-        let times: Range<u64> = Arbitrary::arbitrary(u)?;
-
-        Ok(Self {
-            subspace,
-            path,
-            times,
-        })
-    }
-
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        and_all(&[
-            AreaSubspace::<S>::size_hint(depth),
-            Path::<MCL, MCC, MPL>::size_hint(depth),
-            Range::<u64>::size_hint(depth),
-        ])
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -233,64 +207,51 @@ mod tests {
 
     use super::*;
 
-    #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
-    struct FakeSubspaceId(usize);
-    impl SubspaceId for FakeSubspaceId {
-        fn successor(&self) -> Option<Self> {
-            Some(FakeSubspaceId(self.0 + 1))
-        }
-    }
-
     const MCL: usize = 8;
     const MCC: usize = 4;
     const MPL: usize = 16;
 
     #[test]
     fn subspace_area_includes() {
-        assert!(AreaSubspace::<FakeSubspaceId>::Any.includes(&FakeSubspaceId(5)));
-        assert!(AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(5)).includes(&FakeSubspaceId(5)));
-        assert!(!AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(8)).includes(&FakeSubspaceId(5)));
+        assert!(AreaSubspace::<u64>::Any.includes(&5));
+        assert!(AreaSubspace::<u64>::Id(5).includes(&5));
+        assert!(!AreaSubspace::<u64>::Id(8).includes(&5));
     }
 
     #[test]
     fn subspace_area_intersects() {
         // Non-empty intersections
-        let any_any_intersection =
-            AreaSubspace::<FakeSubspaceId>::Any.intersection(&AreaSubspace::<FakeSubspaceId>::Any);
+        let any_any_intersection = AreaSubspace::<u64>::Any.intersection(&AreaSubspace::<u64>::Any);
 
         assert!(any_any_intersection.is_some());
 
-        assert!(any_any_intersection.unwrap() == AreaSubspace::<FakeSubspaceId>::Any);
+        assert!(any_any_intersection.unwrap() == AreaSubspace::<u64>::Any);
 
-        let any_id_intersection = AreaSubspace::<FakeSubspaceId>::Any
-            .intersection(&AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(6)));
+        let any_id_intersection =
+            AreaSubspace::<u64>::Any.intersection(&AreaSubspace::<u64>::Id(6));
 
         assert!(any_id_intersection.is_some());
 
-        assert!(
-            any_id_intersection.unwrap() == AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(6))
-        );
+        assert!(any_id_intersection.unwrap() == AreaSubspace::<u64>::Id(6));
 
-        let id_id_intersection = AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(6))
-            .intersection(&AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(6)));
+        let id_id_intersection =
+            AreaSubspace::<u64>::Id(6).intersection(&AreaSubspace::<u64>::Id(6));
 
         assert!(id_id_intersection.is_some());
 
-        assert!(
-            id_id_intersection.unwrap() == AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(6))
-        );
+        assert!(id_id_intersection.unwrap() == AreaSubspace::<u64>::Id(6));
 
         // Empty intersections
 
-        let empty_id_id_intersection = AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(7))
-            .intersection(&AreaSubspace::<FakeSubspaceId>::Id(FakeSubspaceId(6)));
+        let empty_id_id_intersection =
+            AreaSubspace::<u64>::Id(7).intersection(&AreaSubspace::<u64>::Id(6));
 
         assert!(empty_id_id_intersection.is_none())
     }
 
     #[test]
     fn area_full() {
-        let full_area = Area::<MCL, MCC, MPL, FakeSubspaceId>::new_full();
+        let full_area = Area::<MCL, MCC, MPL, u64>::new_full();
 
         assert_eq!(
             full_area,
@@ -304,12 +265,12 @@ mod tests {
 
     #[test]
     fn area_subspace() {
-        let subspace_area = Area::<MCL, MCC, MPL, FakeSubspaceId>::new_subspace(FakeSubspaceId(7));
+        let subspace_area = Area::<MCL, MCC, MPL, u64>::new_subspace(7);
 
         assert_eq!(
             subspace_area,
             Area {
-                subspace: AreaSubspace::Id(FakeSubspaceId(7)),
+                subspace: AreaSubspace::Id(7),
                 path: Path::new_empty(),
                 times: Range::new_open(0)
             }
@@ -318,52 +279,52 @@ mod tests {
 
     #[test]
     fn area_intersects() {
-        let empty_intersection_subspace = Area::<MCL, MCC, MPL, FakeSubspaceId> {
-            subspace: AreaSubspace::Id(FakeSubspaceId(1)),
+        let empty_intersection_subspace = Area::<MCL, MCC, MPL, u64> {
+            subspace: AreaSubspace::Id(1),
             path: Path::new_empty(),
             times: Range::new_open(0),
         }
         .intersection(&Area {
-            subspace: AreaSubspace::Id(FakeSubspaceId(2)),
+            subspace: AreaSubspace::Id(2),
             path: Path::new_empty(),
             times: Range::new_open(0),
         });
 
         assert!(empty_intersection_subspace.is_none());
 
-        let empty_intersection_path = Area::<MCL, MCC, MPL, FakeSubspaceId> {
-            subspace: AreaSubspace::Id(FakeSubspaceId(1)),
+        let empty_intersection_path = Area::<MCL, MCC, MPL, u64> {
+            subspace: AreaSubspace::Id(1),
             path: Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
             times: Range::new_open(0),
         }
         .intersection(&Area {
-            subspace: AreaSubspace::Id(FakeSubspaceId(1)),
+            subspace: AreaSubspace::Id(1),
             path: Path::new_from_slice(&[Component::new(b"1").unwrap()]).unwrap(),
             times: Range::new_open(0),
         });
 
         assert!(empty_intersection_path.is_none());
 
-        let empty_intersection_time = Area::<MCL, MCC, MPL, FakeSubspaceId> {
-            subspace: AreaSubspace::Id(FakeSubspaceId(1)),
+        let empty_intersection_time = Area::<MCL, MCC, MPL, u64> {
+            subspace: AreaSubspace::Id(1),
             path: Path::new_empty(),
             times: Range::new_closed(0, 1).unwrap(),
         }
         .intersection(&Area {
-            subspace: AreaSubspace::Id(FakeSubspaceId(1)),
+            subspace: AreaSubspace::Id(1),
             path: Path::new_empty(),
             times: Range::new_closed(2, 3).unwrap(),
         });
 
         assert!(empty_intersection_time.is_none());
 
-        let intersection = Area::<MCL, MCC, MPL, FakeSubspaceId> {
+        let intersection = Area::<MCL, MCC, MPL, u64> {
             subspace: AreaSubspace::Any,
             path: Path::new_from_slice(&[Component::new(b"1").unwrap()]).unwrap(),
             times: Range::new_closed(0, 10).unwrap(),
         }
         .intersection(&Area {
-            subspace: AreaSubspace::Id(FakeSubspaceId(1)),
+            subspace: AreaSubspace::Id(1),
             path: Path::new_from_slice(&[
                 Component::new(b"1").unwrap(),
                 Component::new(b"2").unwrap(),
@@ -377,7 +338,7 @@ mod tests {
         assert_eq!(
             intersection.unwrap(),
             Area {
-                subspace: AreaSubspace::Id(FakeSubspaceId(1)),
+                subspace: AreaSubspace::Id(1),
                 path: Path::new_from_slice(&[
                     Component::new(b"1").unwrap(),
                     Component::new(b"2").unwrap(),

--- a/data-model/src/grouping/area_of_interest.rs
+++ b/data-model/src/grouping/area_of_interest.rs
@@ -1,10 +1,10 @@
-use crate::{grouping::area::Area, parameters::SubspaceId};
+use crate::grouping::area::Area;
 
 /// A grouping of [`crate::Entry`]s that are among the newest in some [store](https://willowprotocol.org/specs/data-model/index.html#store).
 ///
 /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#aois).
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct AreaOfInterest<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> {
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct AreaOfInterest<const MCL: usize, const MCC: usize, const MPL: usize, S> {
     /// To be included in this [`AreaOfInterest`], an [`crate::Entry`] must be included in the [`Area`].
     pub area: Area<MCL, MCC, MPL, S>,
     /// To be included in this AreaOfInterest, an Entry’s timestamp must be among the max_count greatest Timestamps, unless max_count is zero.
@@ -13,9 +13,7 @@ pub struct AreaOfInterest<const MCL: usize, const MCC: usize, const MPL: usize, 
     pub max_size: u64,
 }
 
-impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
-    AreaOfInterest<MCL, MCC, MPL, S>
-{
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> AreaOfInterest<MCL, MCC, MPL, S> {
     /// Creates a new [`AreaOfInterest`].
     pub fn new(area: Area<MCL, MCC, MPL, S>, max_count: u64, max_size: u64) -> Self {
         Self {
@@ -24,7 +22,12 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
             max_size,
         }
     }
+}
 
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> AreaOfInterest<MCL, MCC, MPL, S>
+where
+    S: PartialOrd + Clone,
+{
     /// Returns the intersection of this [`AreaOfInterest`] with another.
     ///
     /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#aoi_intersection).

--- a/data-model/src/grouping/range_3d.rs
+++ b/data-model/src/grouping/range_3d.rs
@@ -4,14 +4,15 @@ use arbitrary::Arbitrary;
 use crate::{
     entry::{Entry, Timestamp},
     grouping::{area::Area, range::Range},
-    parameters::{NamespaceId, PayloadDigest, SubspaceId},
+    parameters::SubspaceId,
     path::Path,
 };
 
 /// A three-dimensional range that includes every Entry included in all three of its ranges.
+///
 /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#D3Range).
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Range3d<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> {
+pub struct Range3d<const MCL: usize, const MCC: usize, const MPL: usize, S> {
     /// A range of [`SubspaceId`]s.
     /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#SubspaceRange).
     subspaces: Range<S>,
@@ -23,9 +24,7 @@ pub struct Range3d<const MCL: usize, const MCC: usize, const MPL: usize, S: Subs
     times: Range<Timestamp>,
 }
 
-impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
-    Range3d<MCL, MCC, MPL, S>
-{
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> Range3d<MCL, MCC, MPL, S> {
     /// Creates a new [`Range3d`].
     pub fn new(
         subspaces: Range<S>,
@@ -37,15 +36,6 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
             paths,
             times,
         }
-    }
-
-    /// Creates a new [`Range3d`] that covers everything.
-    pub fn new_full() -> Self {
-        Self::new(
-            Default::default(),
-            Range::new_open(Path::new_empty()),
-            Default::default(),
-        )
     }
 
     /// Returns a reference to the range of [`SubspaceId`]s.
@@ -68,17 +58,38 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
     pub fn times(&self) -> &Range<Timestamp> {
         &self.times
     }
+}
 
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> Range3d<MCL, MCC, MPL, S>
+where
+    S: Default,
+{
+    /// Creates a new [`Range3d`] that covers everything. Requires `S::default()` to be the least `S` to be correct.
+    pub fn new_full() -> Self {
+        Self::new(
+            Default::default(),
+            Range::new_open(Path::new_empty()),
+            Default::default(),
+        )
+    }
+}
+
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> Range3d<MCL, MCC, MPL, S>
+where
+    S: PartialOrd,
+{
     /// Returns whether an [`Entry`] is [included](https://willowprotocol.org/specs/grouping-entries/index.html#d3_range_include) by this 3d range.
-    pub fn includes_entry<N: NamespaceId, PD: PayloadDigest>(
-        &self,
-        entry: &Entry<MCL, MCC, MPL, N, S, PD>,
-    ) -> bool {
+    pub fn includes_entry<N, PD>(&self, entry: &Entry<MCL, MCC, MPL, N, S, PD>) -> bool {
         self.subspaces.includes(entry.subspace_id())
             && self.paths.includes(entry.path())
             && self.times.includes(&entry.timestamp())
     }
+}
 
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S> Range3d<MCL, MCC, MPL, S>
+where
+    S: Ord + Clone,
+{
     /// Returns the intersection between this [`Range3d`] and another.
     pub fn intersection(&self, other: &Range3d<MCL, MCC, MPL, S>) -> Option<Self> {
         let paths = self.paths.intersection(&other.paths)?;
@@ -92,10 +103,12 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
     }
 }
 
-impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId> Default
+impl<const MCL: usize, const MCC: usize, const MPL: usize, S: Default> Default
     for Range3d<MCL, MCC, MPL, S>
 {
-    /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#default_3d_range).
+    /// The default 3dRange, assuming that `S::default()` yields the default SubspaceId.
+    ///
+    /// [Definition](https://willowprotocol.org/specs/grouping-entries/index.html#default_3d_range)
     fn default() -> Self {
         Self {
             subspaces: Range::<S>::default(),
@@ -117,7 +130,7 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S: SubspaceId>
 impl<'a, const MCL: usize, const MCC: usize, const MPL: usize, S> Arbitrary<'a>
     for Range3d<MCL, MCC, MPL, S>
 where
-    S: SubspaceId + Arbitrary<'a>,
+    S: PartialOrd + Arbitrary<'a>,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
@@ -130,40 +143,9 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use crate::path::Component;
 
     use super::*;
-
-    #[derive(Default, PartialEq, Eq, Clone, Debug)]
-    struct FakeNamespaceId(usize);
-    impl NamespaceId for FakeNamespaceId {}
-
-    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
-    struct FakeSubspaceId(usize);
-    impl SubspaceId for FakeSubspaceId {
-        fn successor(&self) -> Option<Self> {
-            Some(FakeSubspaceId(self.0 + 1))
-        }
-    }
-
-    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
-    struct FakePayloadDigest(usize);
-    impl PayloadDigest for FakePayloadDigest {
-        type Hasher = ();
-
-        fn finish(hasher: &Self::Hasher) -> Self {
-            todo!()
-        }
-
-        fn write(hasher: &mut Self::Hasher, bytes: &[u8]) {
-            todo!()
-        }
-
-        fn hasher() -> Self::Hasher {
-            todo!()
-        }
-    }
 
     const MCL: usize = 8;
     const MCC: usize = 4;
@@ -172,17 +154,16 @@ mod tests {
     #[test]
     fn includes_entry() {
         let entry = Entry::new(
-            FakeNamespaceId::default(),
-            FakeSubspaceId(10),
+            0,
+            10,
             Path::<MCL, MCC, MPL>::new_from_slice(&[Component::new(b"a").unwrap()]).unwrap(),
             500,
             10,
-            FakePayloadDigest::default(),
+            0,
         );
 
         let range_including = Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(9), FakeSubspaceId(11))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(9, 11).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"b").unwrap()]).unwrap(),
@@ -194,8 +175,7 @@ mod tests {
         assert!(range_including.includes_entry(&entry));
 
         let range_subspaces_excluding = Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(11), FakeSubspaceId(13))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(11, 13).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"b").unwrap()]).unwrap(),
@@ -207,8 +187,7 @@ mod tests {
         assert!(!range_subspaces_excluding.includes_entry(&entry));
 
         let range_paths_excluding = Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(9), FakeSubspaceId(11))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(9, 11).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"1").unwrap()]).unwrap(),
@@ -220,8 +199,7 @@ mod tests {
         assert!(!range_paths_excluding.includes_entry(&entry));
 
         let range_times_excluding = Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(9), FakeSubspaceId(11))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(9, 11).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"b").unwrap()]).unwrap(),
@@ -236,8 +214,7 @@ mod tests {
     #[test]
     fn intersection() {
         let empty_intersection_subspace = Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(11), FakeSubspaceId(13))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(11, 13).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"1").unwrap()]).unwrap(),
@@ -246,8 +223,7 @@ mod tests {
             times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
         }
         .intersection(&Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(0, 3).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"1").unwrap()]).unwrap(),
@@ -259,8 +235,7 @@ mod tests {
         assert!(empty_intersection_subspace.is_none());
 
         let empty_intersection_path = Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(0, 3).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"1").unwrap()]).unwrap(),
@@ -269,8 +244,7 @@ mod tests {
             times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
         }
         .intersection(&Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(0, 3).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"4").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"6").unwrap()]).unwrap(),
@@ -282,8 +256,7 @@ mod tests {
         assert!(empty_intersection_path.is_none());
 
         let empty_intersection_time = Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(0, 3).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"1").unwrap()]).unwrap(),
@@ -292,8 +265,7 @@ mod tests {
             times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
         }
         .intersection(&Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(0, 3).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"1").unwrap()]).unwrap(),
@@ -305,8 +277,7 @@ mod tests {
         assert!(empty_intersection_time.is_none());
 
         let intersection = Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(0), FakeSubspaceId(3))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(0, 3).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"0").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"6").unwrap()]).unwrap(),
@@ -315,8 +286,7 @@ mod tests {
             times: Range::<Timestamp>::new_closed(0, 100).unwrap(),
         }
         .intersection(&Range3d {
-            subspaces: Range::<FakeSubspaceId>::new_closed(FakeSubspaceId(2), FakeSubspaceId(4))
-                .unwrap(),
+            subspaces: Range::<u64>::new_closed(2, 4).unwrap(),
             paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                 Path::new_from_slice(&[Component::new(b"3").unwrap()]).unwrap(),
                 Path::new_from_slice(&[Component::new(b"9").unwrap()]).unwrap(),
@@ -330,11 +300,7 @@ mod tests {
         assert_eq!(
             intersection.unwrap(),
             Range3d {
-                subspaces: Range::<FakeSubspaceId>::new_closed(
-                    FakeSubspaceId(2),
-                    FakeSubspaceId(3)
-                )
-                .unwrap(),
+                subspaces: Range::<u64>::new_closed(2, 3).unwrap(),
                 paths: Range::<Path<MCL, MCC, MPL>>::new_closed(
                     Path::new_from_slice(&[Component::new(b"3").unwrap()]).unwrap(),
                     Path::new_from_slice(&[Component::new(b"6").unwrap()]).unwrap(),

--- a/data-model/src/lengthy_entry.rs
+++ b/data-model/src/lengthy_entry.rs
@@ -1,15 +1,10 @@
-use crate::{AuthorisationToken, AuthorisedEntry, Entry, NamespaceId, PayloadDigest, SubspaceId};
+use crate::{AuthorisedEntry, Entry};
 
 /// An [`Entry`] together with information about how much of its payload a given [`Store`] holds.
 ///
 /// [Definition](https://willowprotocol.org/specs/3d-range-based-set-reconciliation/index.html#LengthyEntry)
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LengthyEntry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>
-where
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
-{
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LengthyEntry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD> {
     /// The Entry in question.
     entry: Entry<MCL, MCC, MPL, N, S, PD>,
     /// The number of consecutive bytes from the start of the entry’s payload that the peer holds.
@@ -18,10 +13,6 @@ where
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>
     LengthyEntry<MCL, MCC, MPL, N, S, PD>
-where
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
 {
     /// Returns a new lengthy entry from a given [`Entry`] and the number of consecutive bytes from the start of the entry’s payload that are held.
     pub fn new(entry: Entry<MCL, MCC, MPL, N, S, PD>, available: u64) -> Self {
@@ -46,10 +37,6 @@ where
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>
     AsRef<Entry<MCL, MCC, MPL, N, S, PD>> for LengthyEntry<MCL, MCC, MPL, N, S, PD>
-where
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
 {
     fn as_ref(&self) -> &Entry<MCL, MCC, MPL, N, S, PD> {
         &self.entry
@@ -57,7 +44,7 @@ where
 }
 
 /// An [`AuthorisedEntry`] together with information about how much of its payload a given [`Store`] holds.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LengthyAuthorisedEntry<
     const MCL: usize,
     const MCC: usize,
@@ -66,12 +53,7 @@ pub struct LengthyAuthorisedEntry<
     S,
     PD,
     AT,
-> where
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
-    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
-{
+> {
     /// The Entry in question.
     entry: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
     /// The number of consecutive bytes from the start of the entry’s payload that the peer holds.
@@ -80,11 +62,6 @@ pub struct LengthyAuthorisedEntry<
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
     LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>
-where
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
-    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
 {
     /// Returns a new lengthy entry from a given [`AuthorisedEntry`] and the number of consecutive bytes from the start of the entry’s payload that are held.
     pub fn new(entry: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>, available: u64) -> Self {
@@ -110,11 +87,6 @@ where
 impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
     AsRef<AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>
     for LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>
-where
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
-    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
 {
     fn as_ref(&self) -> &AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT> {
         &self.entry

--- a/data-model/src/parameters.rs
+++ b/data-model/src/parameters.rs
@@ -2,48 +2,59 @@ use crate::entry::Entry;
 use core::fmt::Debug;
 
 /// A type for identifying [namespaces](https://willowprotocol.org/specs/data-model/index.html#namespace).
+///
+/// When an implementing type implements [`PartialOrd`], then `Self::default()` must return a least element with respect to the ordering.
+///
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#NamespaceId).
 
 pub trait NamespaceId: Eq + Default + Clone + Debug {}
 
 /// A type for identifying [subspaces](https://willowprotocol.org/specs/data-model/index.html#subspace).
+///
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#SubspaceId).
 ///
 /// ## Implementation notes
 ///
 /// The [`Default`] implementation **must** return the least element in the total order of [`SubspaceId`].
 pub trait SubspaceId: Ord + Default + Clone + Debug {
-    /// Returns the next possible value in the set of all [`SubspaceId`].
-    ///
-    /// e.g. the successor of 3 is 4.
+    /// Returns the next possible value in the set of all [`SubspaceId`], i.e. the (unique) least value that is strictly greater than `self`. Only if there is no greater value at all may this method return `None`.
     fn successor(&self) -> Option<Self>;
 }
 
 /// A totally ordered type for [content-addressing](https://en.wikipedia.org/wiki/Content_addressing) the data that Willow stores.
+///
+/// This trait mirrors the [`std::hash::Hasher`] trait (with the hasher state as an associated type), but hashing not to `u64`s but to `Self`s.
+///
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#PayloadDigest).
+///
+/// ## Implementation notes
+///
+/// The [`Default`] implementation **must** return the least element in the total order of [`PayloadDigest`].
 pub trait PayloadDigest: Ord + Default + Clone + Debug {
+    /// The state for hashing slices of bytes.
     type Hasher;
 
+    /// Returns the initial state for hashing, i.e., the hash for the empty string.
     fn hasher() -> Self::Hasher;
+
+    /// Returns the digest for the values written so far.
+    ///
+    /// Despite its name, the method does not reset the hasher’s internal state. Additional writes will continue from the current value. If you need to start a fresh hash value, you will have to create a new hasher.
     fn finish(hasher: &Self::Hasher) -> Self;
+
+    /// Writes some data into the given Hasher.
     fn write(hasher: &mut Self::Hasher, bytes: &[u8]);
 }
 
-/// Determines whether this type (nominally a [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken)) is able to prove write permission for a given [`Entry`].
+/// Determines whether this type (nominally an [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken)) is able to prove write permission for a given [`Entry`].
 ///
 /// ## Type parameters
 ///
 /// - `N` - The type used for the [`Entry`]'s [`NamespaceId`].
 /// - `S` - The type used for the [`Entry`]'s [`SubspaceId`].
 /// - `PD` - The type used for the [`Entry`]'s [`PayloadDigest`].
-pub trait AuthorisationToken<
-    const MCL: usize,
-    const MCC: usize,
-    const MPL: usize,
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
->: Clone
+pub trait AuthorisationToken<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>:
+    Clone
 {
     /// Determines whether this type (nominally a [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken)) is able to prove write permission for a given [`Entry`].
     fn is_authorised_write(&self, entry: &Entry<MCL, MCC, MPL, N, S, PD>) -> bool;

--- a/data-model/src/parameters.rs
+++ b/data-model/src/parameters.rs
@@ -43,7 +43,7 @@ pub trait AuthorisationToken<
     N: NamespaceId,
     S: SubspaceId,
     PD: PayloadDigest,
->
+>: Clone
 {
     /// Determines whether this type (nominally a [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken)) is able to prove write permission for a given [`Entry`].
     fn is_authorised_write(&self, entry: &Entry<MCL, MCC, MPL, N, S, PD>) -> bool;

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -321,6 +321,7 @@ where
         &self,
         authorised_entry: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
         prevent_pruning: bool,
+        origin: EntryOrigin,
     ) -> impl Future<
         Output = Result<
             EntryIngestionSuccess<MCL, MCC, MPL, N, S, PD, AT>,

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -187,9 +187,9 @@ pub struct EntryForgottenEvent<const MCL: usize, const MCC: usize, const MPL: us
 where
     S: SubspaceId,
 {
-    subspace: S,
-    path: Path<MCL, MCC, MPL>,
-    timestamp: u64,
+    pub subspace: S,
+    pub path: Path<MCL, MCC, MPL>,
+    pub timestamp: u64,
 }
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize, S> EntryForgottenEvent<MCL, MCC, MPL, S>

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -361,9 +361,7 @@ where
     PD: PayloadDigest,
     AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
 {
-    type FlushError: Display + Error;
-    type BulkIngestionError: Display + Error;
-    type OperationsError: Display + Error;
+    type Error: Display + Error;
 
     /// Returns the [namespace](https://willowprotocol.org/specs/data-model/index.html#namespace) which all of this store's [`AuthorisedEntry`] belong to.
     fn namespace_id(&self) -> &N;
@@ -379,7 +377,7 @@ where
     ) -> impl Future<
         Output = Result<
             EntryIngestionSuccess<MCL, MCC, MPL, N, S, PD, AT>,
-            EntryIngestionError<Self::OperationsError>,
+            EntryIngestionError<Self::Error>,
         >,
     >;
 
@@ -398,7 +396,7 @@ where
         C: BulkConsumer<
             Item = Result<
                 EntryIngestionSuccess<MCL, MCC, MPL, N, S, PD, AT>,
-                EntryIngestionError<Self::OperationsError>,
+                EntryIngestionError<Self::Error>,
             >,
         >,
     {
@@ -444,10 +442,7 @@ where
         path: &Path<MCL, MCC, MPL>,
         payload_source: &mut Producer,
     ) -> impl Future<
-        Output = Result<
-            PayloadAppendSuccess,
-            PayloadAppendError<PayloadSourceError, Self::OperationsError>,
-        >,
+        Output = Result<PayloadAppendSuccess, PayloadAppendError<PayloadSourceError, Self::Error>>,
     >
     where
         Producer: BulkProducer<Item = u8, Error = PayloadSourceError>;
@@ -461,7 +456,7 @@ where
         &self,
         subspace_id: &S,
         path: &Path<MCL, MCC, MPL>,
-    ) -> impl Future<Output = Result<(), Self::OperationsError>>;
+    ) -> impl Future<Output = Result<(), Self::Error>>;
 
     /// Locally forgets all [`AuthorisedEntry`] [included](https://willowprotocol.org/specs/grouping-entries/index.html#area_include) by a given [`AreaOfInterest`], returning the number of forgotten entries.
     ///
@@ -474,7 +469,7 @@ where
         &self,
         area: &Area<MCL, MCC, MPL, S>,
         protected: Option<Area<MCL, MCC, MPL, S>>,
-    ) -> impl Future<Output = Result<usize, Self::OperationsError>>;
+    ) -> impl Future<Output = Result<usize, Self::Error>>;
 
     /// Locally forgets the corresponding payload of the entry with a given path and subspace, or an error if no entry with that path and subspace ID is held by this store or if the entry's payload corresponds to other entries.
     ///
@@ -483,7 +478,7 @@ where
         &self,
         subspace_id: &S,
         path: &Path<MCL, MCC, MPL>,
-    ) -> impl Future<Output = Result<(), Self::OperationsError>>;
+    ) -> impl Future<Output = Result<(), Self::Error>>;
 
     /// Locally forgets all payloads with corresponding ['AuthorisedEntry'] [included](https://willowprotocol.org/specs/grouping-entries/index.html#area_include) by a given [`AreaOfInterest`], returning a count of forgotten payloads. Payloads corresponding to entries *outside* of the given `area` param will be be prevented from being forgotten.
     ///
@@ -494,17 +489,17 @@ where
         &self,
         area: &Area<MCL, MCC, MPL, S>,
         protected: Option<Area<MCL, MCC, MPL, S>>,
-    ) -> impl Future<Output = Result<usize, Self::OperationsError>>;
+    ) -> impl Future<Output = Result<usize, Self::Error>>;
 
     /// Forces persistence of all previous mutations
-    fn flush(&self) -> impl Future<Output = Result<(), Self::FlushError>>;
+    fn flush(&self) -> impl Future<Output = Result<(), Self::Error>>;
 
     /// Returns a [`ufotofu::Producer`] of bytes for the payload corresponding to the given subspace id and path.
     fn payload(
         &self,
         subspace: &S,
         path: &Path<MCL, MCC, MPL>,
-    ) -> impl Future<Output = Result<Option<impl Producer<Item = u8>>, Self::OperationsError>>;
+    ) -> impl Future<Output = Result<Option<impl Producer<Item = u8>>, Self::Error>>;
 
     /// Returns a [`LengthyAuthorisedEntry`] with the given [`Path`] and [subspace](https://willowprotocol.org/specs/data-model/index.html#subspace) ID, if present.
     fn entry(
@@ -513,10 +508,7 @@ where
         path: &Path<MCL, MCC, MPL>,
         ignore: Option<QueryIgnoreParams>,
     ) -> impl Future<
-        Output = Result<
-            Option<LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>,
-            Self::OperationsError,
-        >,
+        Output = Result<Option<LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>, Self::Error>,
     >;
 
     /// Queries which entries are [included](https://willowprotocol.org/specs/grouping-entries/index.html#area_include) by an [`Area`], returning a producer of [`LengthyAuthorisedEntry`] **produced in an arbitrary order decided by the store implementation**.
@@ -528,7 +520,7 @@ where
     ) -> impl Future<
         Output = Result<
             impl Producer<Item = LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>,
-            Self::OperationsError,
+            Self::Error,
         >,
     >;
 
@@ -540,7 +532,7 @@ where
     ) -> impl Future<
         Output = impl Producer<
             Item = StoreEvent<MCL, MCC, MPL, N, S, PD, AT>,
-            Error = EventSenderError<Self::OperationsError>,
+            Error = EventSenderError<Self::Error>,
         >,
     >;
 }

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -337,6 +337,7 @@ where
         entry_producer: &mut P,
         result_consumer: &mut C,
         prevent_pruning: bool,
+        origin: EntryOrigin,
     ) -> impl Future<Output = Result<(), BulkIngestionError<P::Error, C::Error>>>
     where
         P: BulkProducer<Item = AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>,
@@ -356,7 +357,9 @@ where
 
                 match next {
                     Either::Left(authed_entry) => {
-                        let result = self.ingest_entry(authed_entry, prevent_pruning).await;
+                        let result = self
+                            .ingest_entry(authed_entry, prevent_pruning, origin.clone())
+                            .await;
 
                         result_consumer
                             .consume(result)

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -502,11 +502,10 @@ where
         >,
     >;
 
-    /// Queries which entries are [included](https://willowprotocol.org/specs/grouping-entries/index.html#area_include) by an [`Area`], returning a producer of [`LengthyAuthorisedEntry`].
+    /// Queries which entries are [included](https://willowprotocol.org/specs/grouping-entries/index.html#area_include) by an [`Area`], returning a producer of [`LengthyAuthorisedEntry`] **produced in an arbitrary order decided by the store implementation**.
     fn query_area(
         &self,
         area: &Area<MCL, MCC, MPL, S>,
-        order: &QueryOrder,
         reverse: bool,
         ignore: Option<QueryIgnoreParams>,
     ) -> impl Future<

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -521,8 +521,10 @@ where
         &self,
         area: &Area<MCL, MCC, MPL, S>,
         ignore: Option<QueryIgnoreParams>,
-    ) -> impl Producer<
-        Item = StoreEvent<MCL, MCC, MPL, N, S, PD, AT>,
-        Error = EventSenderError<Self::OperationsError>,
+    ) -> impl Future<
+        Output = impl Producer<
+            Item = StoreEvent<MCL, MCC, MPL, N, S, PD, AT>,
+            Error = EventSenderError<Self::OperationsError>,
+        >,
     >;
 }

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -9,7 +9,7 @@ use ufotofu::{BulkConsumer, BulkProducer, Producer};
 
 use crate::{
     entry::AuthorisedEntry,
-    grouping::Area,
+    grouping::{Area, AreaSubspace, Range},
     parameters::{AuthorisationToken, NamespaceId, PayloadDigest, SubspaceId},
     LengthyAuthorisedEntry, Path,
 };
@@ -166,61 +166,11 @@ pub enum QueryOrder {
     Arbitrary,
 }
 
-/// Describes an [`AuthorisedEntry`] which was successfully ingested into the store, and a [`EntryOrigin`] describing where the entry came from.
-#[derive(Debug, Clone)]
-pub struct IngestEvent<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
-where
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
-    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
-{
-    /// The entry which was ingested
-    pub ingested: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
-    /// The origin of the ingestion
-    pub origin: EntryOrigin,
-}
-
-/// Describes a forgotten entry by its subspace, path, and timestamp.
-#[derive(Debug, Clone)]
-pub struct EntryForgottenEvent<const MCL: usize, const MCC: usize, const MPL: usize, S>
-where
-    S: SubspaceId,
-{
-    pub subspace: S,
-    pub path: Path<MCL, MCC, MPL>,
-    pub timestamp: u64,
-}
-
-impl<const MCL: usize, const MCC: usize, const MPL: usize, S> EntryForgottenEvent<MCL, MCC, MPL, S>
-where
-    S: SubspaceId,
-{
-    pub fn new(subspace: S, path: Path<MCL, MCC, MPL>, timestamp: u64) -> Self {
-        Self {
-            subspace,
-            path,
-            timestamp,
-        }
-    }
-}
-
-/// Describes an [`AuthorisedEntry`] which was pruned and the [`AuthorisedEntry`] which triggered the pruning.
-#[derive(Debug, Clone)]
-pub struct PruneEvent<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
-where
-    N: NamespaceId,
-    S: SubspaceId,
-    PD: PayloadDigest,
-    AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
-{
-    /// The subspace ID, path, and timestamp of the entry which was pruned.
-    pub pruned: (S, Path<MCL, MCC, MPL>, u64),
-    /// The entry which triggered the pruning.
-    pub by: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
-}
-
-/// An event which took place within a [`Store`].
+/// A notification about changes in a [`Store`]. You can obtain a producer of these via the [`Store::subscribe_area`] method.
+///
+/// An event subscription takes two parameters: the [`Area`] within events should be reported (any store mutations outside that area will not be reported to that subscription), and some optional `QueryIgnoreParams` for optionally filtering events based on whether they correspond to entries whose payload is the empty string and/or whose payload is not fully available in the local store. A more detailed description of how these ignore options impact events is given in the docs for each enum variant, but the general intuition is for the subscription to act as if it was on a store that did not inlcude ignored entries in the first place.
+///
+/// In the description of the enum variants, we write `sub_area` for the area of the subscription, and `ignores` for the subscription `QueryIgnoreParams`.
 #[derive(Debug, Clone)]
 pub enum StoreEvent<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
 where
@@ -229,16 +179,59 @@ where
     PD: PayloadDigest,
     AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
 {
-    /// A new entry was ingested.
-    Ingested(IngestEvent<MCL, MCC, MPL, N, S, PD, AT>),
-    /// An existing entry received a portion of its corresponding payload.
+    /// Emitted when an entry is inserted in `area`.
+    ///
+    /// - If `ignores.ignore_empty_payloads`, this is not emitted if the payload of the entry is the empty payload.
+    /// - If `ignores.ignore_incomplete_payloads`, this event is not emitted upon entry insertion, but only once its payload has been fully added to the store. In this case, the ingestion event is guaranteed to be emitted *before* the corresponding payload append event.
+    Ingested {
+        /// The entry that was inserted.
+        entry: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
+        /// A tag that determines whether we ourselves *created* this entry, or whether it arrived from some other data source. In the latter case, the data source is identified by a u64 id. This is not necessarily intented for application-dev-facing APIs, but rather for efficiently implementing replication services (where you want to forward new entries to other peers, but not to those from which you have just received them).
+        origin: EntryOrigin,
+    },
+    /// Emitted whenever one or more entries are removed from `area` (via prefix pruning) because of an insertion that did not itself happen inside `area`. Example: `area.path` is `["blog", "recipes"]`, and a new entry is written to `[blog]`, thus deleting all old recipes.
+    ///
+    /// Of the "one or more entries", at least one must not have been ignored by the `ignores`. If all deleted entries are ignored, no corresponding `Pruned` event is emitted.
+    ///
+    /// Note that no such event is emitted when the insertion falls *into* `area`; subscribers must monitor `StoreEvent::Ingested` events and infer any deletions from those.
+    Pruned {
+        /// The path of the entry that caused the pruning.
+        path: Path<MCL, MCC, MPL>,
+        /// The subspace_id of the entry that caused the pruning.
+        subspace_id: S,
+        /// The timestamp of the entry that caused the pruning.
+        timestamp: u64,
+    },
+    /// An existing entry inside `area` received a portion of its corresponding payload.
+    ///
+    /// If `ignores.ignore_incomplete_payloads`, this is only emitted when the payload is now fully available. In this case, the corresponding `Ingested` event is guaranteed to be emitted before this `Appended` event.
     Appended(LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>),
-    /// An entry was forgotten.
-    EntryForgotten(EntryForgottenEvent<MCL, MCC, MPL, S>),
-    /// A payload was forgotten.
+    /// Emitted whenever a non-ignored entry in `area` is forgotten via `Store::forget_entry`. No corresponding `PayloadForgotten` event is emitted in this case.
+    EntryForgotten {
+        /// The path of the forgotten entry.
+        path: Path<MCL, MCC, MPL>,
+        /// The subspace_id of the forgotten entry.
+        subspace_id: S,
+        /// The timestamp of the forgotten entry.
+        timestamp: u64,
+        // TODO authorised entry instead? Also the payload maybe? Apps might need to retrieve the payload in order to "undo" operations encoded therein, but also the whole point is to get rid of the payload, not to store it for event consumers. Will probably keep things without the payload for now, but there might be a future API that enables payload access.
+    },
+    /// Emitted whenever a call to `Store::forget_area` forgets at least one non-ignored entry in `area`. No corresponding `AreaPayloadForgotten` event is emitted in this case.
+    AreaForgotten {
+        /// The area that was forgotten.
+        area: Area<MCL, MCC, MPL, S>,
+        /// A subarea that was retained (if any).
+        protected: Option<Area<MCL, MCC, MPL, S>>,
+    },
+    /// Emitted whenever the payload of a non-ignored entry in `area` is forgotten via `Store::forget_payload`. Emitted even if no payload bytes had been available to forget in the first place.
     PayloadForgotten(AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>),
-    /// An entry was pruned via prefix pruning.
-    Pruned(PruneEvent<MCL, MCC, MPL, N, S, PD, AT>),
+    /// Emitted whenever the payload of at least one non-ignored entry in `area` is forgotten via `Store::forget_area_payloads` Emitted even if no payload bytes had been available to forget in the first place.
+    AreaPayloadsForgotten {
+        /// The area whose payloads were forgotten.
+        area: Area<MCL, MCC, MPL, S>,
+        /// A subarea whose payloads were retained (if any).
+        protected: Option<Area<MCL, MCC, MPL, S>>,
+    },
 }
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>
@@ -251,21 +244,45 @@ where
 {
     pub fn included_by_area(&self, area: &Area<MCL, MCC, MPL, S>) -> bool {
         match self {
-            StoreEvent::Ingested(event) => area.includes_entry(event.ingested.entry()),
+            StoreEvent::Ingested { entry, origin: _ } => area.includes_entry(entry.entry()),
             StoreEvent::Appended(lengthy_authorised_entry) => {
                 area.includes_entry(lengthy_authorised_entry.entry().entry())
             }
-            StoreEvent::EntryForgotten(event) => {
-                area.subspace().includes(&event.subspace)
-                    && area.path().is_prefix_of(&event.path)
-                    && area.times().includes(&event.timestamp)
+            StoreEvent::EntryForgotten {
+                path,
+                subspace_id,
+                timestamp,
+            } => {
+                area.subspace().includes(subspace_id)
+                    && area.path().is_prefix_of(path)
+                    && area.times().includes(timestamp)
             }
             StoreEvent::PayloadForgotten(entry) => area.includes_entry(entry.entry()),
-            StoreEvent::Pruned(prune_event) => {
-                area.subspace().includes(&prune_event.pruned.0)
-                    && area.path().is_prefix_of(&prune_event.pruned.1)
-                    && area.times().includes(&prune_event.pruned.2)
+            StoreEvent::Pruned {
+                subspace_id,
+                path,
+                timestamp,
+            } => {
+                // To be included by an area,
+                // The originating entry must exist OUTSIDE the area
+                // AND the area pruned by that entry must intersect with the given area
+                !area.includes_triplet(subspace_id, path, *timestamp)
+                    && Area::new(
+                        AreaSubspace::Id(subspace_id.clone()),
+                        path.clone(),
+                        Range::new_closed(0, *timestamp).unwrap(),
+                    )
+                    .intersection(area)
+                    .is_some()
             }
+            StoreEvent::AreaForgotten {
+                area: forgotten_area,
+                protected: _,
+            } => area.intersection(forgotten_area).is_some(),
+            StoreEvent::AreaPayloadsForgotten {
+                area: forgotten_area,
+                protected: _,
+            } => area.intersection(forgotten_area).is_some(),
         }
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 ufotofu = { version = "0.6.2", features = ["std", "dev"] }
 # ufotofu = { path = "../../ufotofu/ufotofu", features = ["std", "dev"] }
-ufotofu_queues = { version = "0.5.0", features = ["std"] }
+ufotofu_queues = { version = "0.6.0", features = ["std"] }
 pollster = "0.4.0"
 arbitrary = { version = "1.0.2", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }

--- a/fuzz/src/store.rs
+++ b/fuzz/src/store.rs
@@ -113,7 +113,7 @@ where
 
     type BulkIngestionError = Infallible;
 
-    type OperationsError = Infallible;
+    type Error = Infallible;
 
     fn namespace_id(&self) -> &N {
         &self.namespace
@@ -123,10 +123,8 @@ where
         &self,
         authorised_entry: AuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>,
         prevent_pruning: bool,
-    ) -> Result<
-        EntryIngestionSuccess<MCL, MCC, MPL, N, S, PD, AT>,
-        EntryIngestionError<Self::OperationsError>,
-    > {
+    ) -> Result<EntryIngestionSuccess<MCL, MCC, MPL, N, S, PD, AT>, EntryIngestionError<Self::Error>>
+    {
         if self.namespace_id() != authorised_entry.entry().namespace_id() {
             panic!("Tried to ingest an entry into a store with a mismatching NamespaceId");
         }
@@ -189,7 +187,7 @@ where
         subspace: &S,
         path: &Path<MCL, MCC, MPL>,
         payload_source: &mut Producer,
-    ) -> Result<PayloadAppendSuccess, PayloadAppendError<PayloadSourceError, Self::OperationsError>>
+    ) -> Result<PayloadAppendSuccess, PayloadAppendError<PayloadSourceError, Self::Error>>
     where
         Producer: ufotofu::BulkProducer<Item = u8, Error = PayloadSourceError>,
     {
@@ -243,7 +241,7 @@ where
         &self,
         subspace_id: &S,
         path: &Path<MCL, MCC, MPL>,
-    ) -> Result<(), Self::OperationsError> {
+    ) -> Result<(), Self::Error> {
         let mut subspace_store = self.get_or_create_subspace_store(subspace_id);
         subspace_store.entries.remove(path);
         Ok(())
@@ -253,7 +251,7 @@ where
         &self,
         area: &willow_data_model::grouping::Area<MCL, MCC, MPL, S>,
         protected: Option<willow_data_model::grouping::Area<MCL, MCC, MPL, S>>,
-    ) -> Result<usize, Self::OperationsError> {
+    ) -> Result<usize, Self::Error> {
         let mut candidates = vec![];
 
         let mut count = 0;
@@ -297,7 +295,7 @@ where
         &self,
         subspace_id: &S,
         path: &Path<MCL, MCC, MPL>,
-    ) -> Result<(), Self::OperationsError> {
+    ) -> Result<(), Self::Error> {
         let mut subspace_store = self.get_or_create_subspace_store(subspace_id);
         match subspace_store.entries.get_mut(path) {
             None => panic!("Tried to forget the payload of an entry we do not have."),
@@ -312,7 +310,7 @@ where
         &self,
         area: &Area<MCL, MCC, MPL, S>,
         protected: Option<Area<MCL, MCC, MPL, S>>,
-    ) -> Result<usize, Self::OperationsError> {
+    ) -> Result<usize, Self::Error> {
         let mut candidates = vec![];
 
         let mut count = 0;
@@ -360,7 +358,7 @@ where
         &self,
         subspace: &S,
         path: &Path<MCL, MCC, MPL>,
-    ) -> Result<Option<impl Producer<Item = u8>>, Self::OperationsError> {
+    ) -> Result<Option<impl Producer<Item = u8>>, Self::Error> {
         let mut subspace_store = self.get_or_create_subspace_store(subspace);
         match subspace_store.entries.get_mut(path) {
             None => Ok(None),
@@ -373,8 +371,7 @@ where
         subspace_id: &S,
         path: &Path<MCL, MCC, MPL>,
         ignore: Option<QueryIgnoreParams>,
-    ) -> Result<Option<LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>, Self::OperationsError>
-    {
+    ) -> Result<Option<LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>, Self::Error> {
         let subspace_store = self.get_or_create_subspace_store(subspace_id);
         match subspace_store.entries.get(path) {
             None => Ok(None),
@@ -420,7 +417,7 @@ where
         ignore: Option<willow_data_model::QueryIgnoreParams>,
     ) -> Result<
         impl Producer<Item = LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>,
-        Self::OperationsError,
+        Self::Error,
     > {
         let mut candidates = vec![];
 

--- a/lcmux/Cargo.toml
+++ b/lcmux/Cargo.toml
@@ -12,7 +12,7 @@ ufotofu = { version = "0.6.0", features = ["std"] }
 ufotofu_codec = { path = "../ufotofu_codec", version = "0.1.0" }
 ufotofu_codec_endian = { path = "../ufotofu_codec_endian", version = "0.1.0" }
 compact_u64 = { path = "../compact_u64", version = "0.1.0" }
-ufotofu_queues = { version = "0.5.0", features = ["std"] }
+ufotofu_queues = { version = "0.6.0", features = ["std"] }
 async_cell = "0.2.2"
 futures = { version = "0.3.31" }
 willow-encoding = { path = "../encoding", version = "0.1.0" }

--- a/store_simple_sled/Cargo.toml
+++ b/store_simple_sled/Cargo.toml
@@ -10,8 +10,8 @@ workspace = true
 sled = "0.34.7"
 willow-data-model = { path = "../data-model", version = "0.1.0" }
 ufotofu_codec = { path = "../ufotofu_codec", version = "0.1.0" }
-ufotofu = { version = "0.6.0" }
+ufotofu = { version = "0.6.3" }
 ufotofu_codec_endian = { path = "../ufotofu_codec_endian", version = "0.1.0" }
 either = "1.10.0"
-wb_async_utils = { path = "../wb_async_utils", version = "0.1.0" }
+wb_async_utils = { path = "../wb_async_utils", version = "0.1.0", features = ["ufotofu_utils"] }
 ufotofu_queues = { version = "0.6.0", features = ["std"] }

--- a/store_simple_sled/Cargo.toml
+++ b/store_simple_sled/Cargo.toml
@@ -13,3 +13,5 @@ ufotofu_codec = { path = "../ufotofu_codec", version = "0.1.0" }
 ufotofu = { version = "0.6.0" }
 ufotofu_codec_endian = { path = "../ufotofu_codec_endian", version = "0.1.0" }
 either = "1.10.0"
+wb_async_utils = { path = "../wb_async_utils", version = "0.1.0" }
+ufotofu_queues = { version = "0.6.0", features = ["std"] }

--- a/store_simple_sled/src/lib.rs
+++ b/store_simple_sled/src/lib.rs
@@ -668,6 +668,7 @@ where
         EntryProducer::new(self, area, order, reverse, ignore).await
     }
 
+    #[allow(refining_impl_trait)]
     fn subscribe_area(
         &self,
         area: &willow_data_model::grouping::Area<MCL, MCC, MPL, S>,
@@ -1140,5 +1141,14 @@ where
         };
 
         (pack, receiver)
+    }
+
+    fn send_event(&self, event: StoreEvent<MCL, MCC, MPL, N, S, PD, AT>) -> Result<(), ()> {
+        if event.included_by_area(&self.area) {
+            // need some trait satisfaction here
+            self.sender.consume()
+        }
+
+        todo!()
     }
 }

--- a/store_simple_sled/src/lib.rs
+++ b/store_simple_sled/src/lib.rs
@@ -983,14 +983,13 @@ where
     async fn query_area(
         &self,
         area: &Area<MCL, MCC, MPL, S>,
-        order: &QueryOrder,
         reverse: bool,
         ignore: Option<QueryIgnoreParams>,
     ) -> Result<
         impl Producer<Item = LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>,
         Self::OperationsError,
     > {
-        EntryProducer::new(self, area, order, reverse, ignore).await
+        EntryProducer::new(self, area, reverse, ignore).await
     }
 
     async fn subscribe_area(
@@ -1311,8 +1310,6 @@ where
     async fn new(
         store: &'store StoreSimpleSled<MCL, MCC, MPL, N, S, PD, AT>,
         area: &Area<MCL, MCC, MPL, S>,
-        // TODO: discuss order with aljoscha again
-        order: &QueryOrder,
         reverse: bool,
         ignore: Option<QueryIgnoreParams>,
     ) -> Result<Self, SimpleStoreSledError> {

--- a/store_simple_sled/src/lib.rs
+++ b/store_simple_sled/src/lib.rs
@@ -1433,7 +1433,6 @@ where
     PD: PayloadDigest,
     AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
 {
-    id: u64,
     area: Area<MCL, MCC, MPL, S>,
     ignore: Option<QueryIgnoreParams>,
     sender: Mutex<

--- a/store_simple_sled/src/lib.rs
+++ b/store_simple_sled/src/lib.rs
@@ -701,14 +701,16 @@ where
         Ok(None)
     }
 
-    #[allow(refining_impl_trait)]
     async fn query_area(
         &self,
         area: &Area<MCL, MCC, MPL, S>,
         order: &QueryOrder,
         reverse: bool,
-        ignore: Option<willow_data_model::QueryIgnoreParams>,
-    ) -> Result<EntryProducer<MCL, MCC, MPL, N, S, PD, AT>, SimpleStoreSledError> {
+        ignore: Option<QueryIgnoreParams>,
+    ) -> Result<
+        impl Producer<Item = LengthyAuthorisedEntry<MCL, MCC, MPL, N, S, PD, AT>>,
+        Self::OperationsError,
+    > {
         EntryProducer::new(self, area, order, reverse, ignore).await
     }
 

--- a/store_simple_sled/src/lib.rs
+++ b/store_simple_sled/src/lib.rs
@@ -378,6 +378,10 @@ where
             all_payloads_incomplete: true,
         });
 
+        // we would like a big queue, but instead we’ve got many queues for each subscription, which is why things block here. anything that blocks here blocks the whole store.
+        // this is a consequence of us using a channel per subscription.
+        // it can be fixed by maintaining a single event queue which subscribers work through independently
+        //    and, incidentally, subscribers that straggle behind can be offed.
         for event in events_to_emit {
             self.send_event(&event).await;
         }
@@ -732,6 +736,10 @@ where
                 },
             )?;
 
+        // we would like a big queue, but instead we’ve got many queues for each subscription, which is why things block here. anything that blocks here blocks the whole store.
+        // this is a consequence of us using a channel per subscription.
+        // it can be fixed by maintaining a single event queue which subscribers work through independently
+        //    and, incidentally, subscribers that straggle behind can be offed.
         for event in events_to_send {
             self.send_event(&event).await;
         }
@@ -889,6 +897,10 @@ where
             },
         )?;
 
+        // we would like a big queue, but instead we’ve got many queues for each subscription, which is why things block here. anything that blocks here blocks the whole store.
+        // this is a consequence of us using a channel per subscription.
+        // it can be fixed by maintaining a single event queue which subscribers work through independently
+        //    and, incidentally, subscribers that straggle behind can be offed.
         for event in events_to_send {
             self.send_event(&event).await;
         }
@@ -1421,10 +1433,9 @@ where
     PD: PayloadDigest,
     AT: AuthorisationToken<MCL, MCC, MPL, N, S, PD>,
 {
-    // Use these two to determine if we should send an event here
+    id: u64,
     area: Area<MCL, MCC, MPL, S>,
     ignore: Option<QueryIgnoreParams>,
-    // TODO: Use an WB mutex instead of a refcell here.
     sender: Mutex<
         Sender<
             std::rc::Rc<
@@ -1439,7 +1450,6 @@ where
             EventSenderError<SimpleStoreSledError>,
         >,
     >,
-    // No sender here because we give ownership of that to the caller of the function?
 }
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, AT>

--- a/wb_async_utils/Cargo.toml
+++ b/wb_async_utils/Cargo.toml
@@ -11,7 +11,7 @@ ufotofu_utils = ["ufotofu", "ufotofu_queues", "either"]
 [dependencies]
 ufotofu = { version = "0.6.1", features = ["std", "dev"], optional = true }
 # ufotofu = { path = "../../ufotofu/ufotofu", features = ["std", "dev"], optional = true }
-ufotofu_queues = { version = "0.5.0", features = ["std"], optional = true }
+ufotofu_queues = { version = "0.6.0", features = ["std"], optional = true }
 either = { version = "1.10.0", optional = true }
 fairly_unsafe_cell = { path = "../fairly_unsafe_cell", version = "0.1.0" }
 

--- a/wgps/Cargo.toml
+++ b/wgps/Cargo.toml
@@ -9,7 +9,7 @@ willow-data-model = { path = "../data-model", version = "0.1.0" }
 ufotofu_codec = { path = "../ufotofu_codec", version = "0.1.0" }
 ufotofu = { version = "0.6.0", features = ["std"] }
 lcmux = { path = "../lcmux", version = "0.1.0" }
-ufotofu_queues = { version = "0.5.0", features = ["std"] }
+ufotofu_queues = { version = "0.6.0", features = ["std"] }
 futures = { version = "0.3.31" }
 either = "1.10.0"
 async_cell = "0.2.2"


### PR DESCRIPTION
- Add `Clone` to `AuthorisationToken`
- Refactor `StoreEvent` to not be full of horrible tuples, but horrible structs instead
- Add `origin` param to `Store#ingest_entry`
- Removed `order` param for `Store#query_area`
- Implement `StoreSimpleSled#new` and `StoreSimpleSled#from_existing`
- Send events when things happen in the store.
- Fix bugs in `StoreSimpleSled#append_payload`
- Interpret `QueryIgnoreParams` the way they are meant to be interpreted.
- Make error conversion a *bit* nicer 