### PR TITLE
TrustedDecodable + RelativeTrustedDecodable traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7eda79bbd84e29c2b308d1dc099d7de8dcc7035e48f4bf5dc4a531a44ff5e2a"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel",
  "async-io",
@@ -117,14 +117,13 @@ dependencies = [
  "futures-lite",
  "rustix",
  "tracing",
- "windows-sys",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794f185324c2f00e771cd9f1ae8b5ac68be2ca7abb129a87afd6e86d228bc54d"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
  "async-io",
  "async-lock",
@@ -158,9 +157,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "base64ct"
@@ -176,15 +175,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blake3"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a796731680be7931955498a16a10b2270c7762963d5d570fdbfe02dcbf314f"
+checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -223,15 +222,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "jobserver",
  "libc",
@@ -305,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -358,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -404,15 +403,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -420,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -431,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -521,9 +520,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -600,7 +599,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -620,10 +631,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -652,20 +664,19 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
- "once_cell",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -679,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "meadowcap"
@@ -704,16 +715,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -742,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -754,9 +759,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -775,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.2"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -805,21 +810,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -876,7 +887,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -917,11 +928,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -942,18 +953,18 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1022,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smol"
@@ -1061,9 +1072,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1093,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -1103,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 
 [[package]]
 name = "typenum"
@@ -1151,9 +1162,9 @@ checksum = "9abd2f0123cc71fa3adf9329b85d9eb863874e489744803f3a41fff59b56968d"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "version_check"
@@ -1166,6 +1177,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wb_async_utils"
@@ -1266,6 +1286,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "blake3",
+ "compact_u64",
  "ed25519-dalek",
  "meadowcap",
  "rand 0.8.5",
@@ -1273,6 +1294,7 @@ dependencies = [
  "ufotofu",
  "ufotofu_codec",
  "willow-data-model",
+ "willow-encoding",
 ]
 
 [[package]]
@@ -1299,9 +1321,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -1369,6 +1391,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
 
 [[package]]
 name = "zerocopy"

--- a/data-model/src/grouping/area.rs
+++ b/data-model/src/grouping/area.rs
@@ -4,7 +4,7 @@ use arbitrary::Arbitrary;
 use crate::{
     entry::{Entry, Timestamp},
     grouping::RangeEnd,
-    parameters::{NamespaceId, PayloadDigest, SubspaceId},
+    parameters::SubspaceId,
     path::Path,
     PathBuilder,
 };

--- a/data-model/src/lib.rs
+++ b/data-model/src/lib.rs
@@ -26,6 +26,8 @@
 //! - `AT` - The type used for [`AuthorisationToken`](https://willowprotocol.org/specs/data-model/index.html#AuthorisationToken) (willowprotocol.org), must implement the [`AuthorisationToken`] trait.
 
 mod entry;
+use std::future::Future;
+
 pub use entry::*;
 mod lengthy_entry;
 pub use lengthy_entry::*;
@@ -39,3 +41,29 @@ pub use private_encodings::*;
 mod relative_encodings;
 mod store;
 pub use store::*;
+use ufotofu_codec::Blame;
+
+/// Methods for decoding **trusted** encodings,that is, data which was already deemed trustworthy *prior* to encoding.
+pub trait TrustedDecodable: Sized {
+    /// # Safety
+    /// This function is only intended to decode types which have been deemed *trusted* prior to their encoding.
+    /// Using it to decode encodings from untrusted sources will result in immediate undefined behaviour!
+    unsafe fn trusted_decode<P>(
+        producer: &mut P,
+    ) -> impl Future<Output = Result<Self, ufotofu_codec::DecodeError<P::Final, P::Error, Blame>>>
+    where
+        P: ufotofu::BulkProducer<Item = u8>;
+}
+
+/// Methods for decoding **trusted** encodings (that is, data which was deemed trustworthy *prior* to encoding), **relative** to type `R`.
+pub trait TrustedRelativeDecodable<R>: Sized {
+    /// # Safety
+    /// This function is only intended to decode types which have been deemed *trusted* prior to their encoding.
+    /// Using it to decode encodings from untrusted sources will result in immediate undefined behaviour!
+    unsafe fn trusted_relative_decode<P>(
+        producer: &mut P,
+        r: &R,
+    ) -> impl Future<Output = Result<Self, ufotofu_codec::DecodeError<P::Final, P::Error, Blame>>>
+    where
+        P: ufotofu::BulkProducer<Item = u8>;
+}

--- a/fuzz/fuzz_targets/enc_mccapability_rel_area.rs
+++ b/fuzz/fuzz_targets/enc_mccapability_rel_area.rs
@@ -1,9 +1,8 @@
 #![no_main]
 
-use meadowcap::McCapability;
+use meadowcap::{McCapability, SillyPublicKey, SillySig};
 use ufotofu_codec::{fuzz_relative_all, Blame};
 use willow_data_model::grouping::Area;
-use willow_fuzz::silly_sigs::{SillyPublicKey, SillySig};
 
 fuzz_relative_all!(McCapability<16, 16, 16, SillyPublicKey, SillySig, SillyPublicKey, SillySig>; Area<16, 16, 16, SillyPublicKey>; Blame; Blame; |cap: &McCapability<16, 16, 16, SillyPublicKey, SillySig, SillyPublicKey, SillySig>, area: &Area<16, 16, 16, SillyPublicKey>| {
     area.includes_area(&cap.granted_area())

--- a/fuzz/fuzz_targets/store.rs
+++ b/fuzz/fuzz_targets/store.rs
@@ -1,10 +1,5 @@
 #![no_main]
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
-
 use libfuzzer_sys::fuzz_target;
 use tempdir::TempDir;
 use willow_fuzz::{

--- a/fuzz/src/placeholder_params.rs
+++ b/fuzz/src/placeholder_params.rs
@@ -1,10 +1,7 @@
 use std::hash::{DefaultHasher, Hasher};
 
 use arbitrary::Arbitrary;
-use meadowcap::{
-    IsCommunal, McAuthorisationToken, McNamespacePublicKey, McPublicUserKey, SillyPublicKey,
-    SillySig,
-};
+use meadowcap::{McPublicUserKey, SillyPublicKey, SillySig};
 use signature::Verifier;
 use ufotofu::{BulkConsumer, BulkProducer};
 use ufotofu_codec::{
@@ -12,7 +9,9 @@ use ufotofu_codec::{
     EncodableSync,
 };
 use ufotofu_codec_endian::U64BE;
-use willow_data_model::{AuthorisationToken, NamespaceId, PayloadDigest, SubspaceId};
+use willow_data_model::{
+    AuthorisationToken, NamespaceId, PayloadDigest, SubspaceId, TrustedDecodable,
+};
 
 async fn encode_bytes<const BYTES_LENGTH: usize, C>(
     bytes: &[u8; BYTES_LENGTH],
@@ -283,5 +282,16 @@ impl Decodable for FakeAuthorisationToken {
         Self: Sized,
     {
         Ok(Self(SillySig::decode(producer).await?))
+    }
+}
+
+impl TrustedDecodable for FakeAuthorisationToken {
+    async unsafe fn trusted_decode<P>(
+        producer: &mut P,
+    ) -> Result<Self, ufotofu_codec::DecodeError<P::Final, P::Error, Blame>>
+    where
+        P: ufotofu::BulkProducer<Item = u8>,
+    {
+        Self::decode(producer).await
     }
 }

--- a/meadowcap/src/communal_capability.rs
+++ b/meadowcap/src/communal_capability.rs
@@ -111,7 +111,7 @@ where
             user: new_user,
         };
 
-        let handover_enc = &handover.sync_encode_into_boxed_slice();
+        let handover_enc = handover.sync_encode_into_boxed_slice();
 
         let signature = secret_key.sign(&handover_enc);
 
@@ -241,6 +241,23 @@ where
     pub fn progenitor(&self) -> &UserPublicKey {
         &self.user_key
     }
+
+    /// Returns a [`CommunalCapability`] without checking if any of the delegations are valid.
+    ///
+    /// Calling this method with an invalid delegation check is immediate undefined behaviour!
+    pub unsafe fn new_unchecked(
+        access_mode: AccessMode,
+        namespace_key: NamespacePublicKey,
+        user_key: UserPublicKey,
+        delegations: Vec<Delegation<MCL, MCC, MPL, UserPublicKey, UserSignature>>,
+    ) -> Self {
+        Self {
+            access_mode,
+            namespace_key,
+            user_key,
+            delegations,
+        }
+    }
 }
 
 /// Can be encoded to a bytestring to be signed for a new [`Delegation`] to a [`CommunalCapability`].
@@ -265,7 +282,6 @@ pub struct CommunalHandover<
 }
 
 impl<
-        'a,
         const MCL: usize,
         const MCC: usize,
         const MPL: usize,
@@ -273,7 +289,7 @@ impl<
         UserPublicKey,
         UserSignature,
     > Encodable
-    for CommunalHandover<'a, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
+    for CommunalHandover<'_, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
 where
     NamespacePublicKey: McNamespacePublicKey,
     UserPublicKey: McPublicUserKey<UserSignature>,
@@ -316,7 +332,6 @@ where
 }
 
 impl<
-        'a,
         const MCL: usize,
         const MCC: usize,
         const MPL: usize,
@@ -324,7 +339,7 @@ impl<
         UserPublicKey,
         UserSignature,
     > EncodableKnownSize
-    for CommunalHandover<'a, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
+    for CommunalHandover<'_, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
 where
     NamespacePublicKey: McNamespacePublicKey,
     UserPublicKey: McPublicUserKey<UserSignature>,
@@ -356,7 +371,6 @@ where
 }
 
 impl<
-        'a,
         const MCL: usize,
         const MCC: usize,
         const MPL: usize,
@@ -364,7 +378,7 @@ impl<
         UserPublicKey,
         UserSignature,
     > EncodableSync
-    for CommunalHandover<'a, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
+    for CommunalHandover<'_, MCL, MCC, MPL, NamespacePublicKey, UserPublicKey, UserSignature>
 where
     NamespacePublicKey: McNamespacePublicKey,
     UserPublicKey: McPublicUserKey<UserSignature>,

--- a/meadowcap/src/mc_capability.rs
+++ b/meadowcap/src/mc_capability.rs
@@ -13,10 +13,10 @@ use compact_u64::{CompactU64, Tag, TagWidth};
 use either::Either;
 use signature::{Error as SignatureError, Signer, Verifier};
 use ufotofu_codec::{
-    Blame, DecodableCanonic, DecodeError, Encodable, EncodableKnownSize, EncodableSync,
+    Blame, Decodable, DecodableCanonic, DecodeError, Encodable, EncodableKnownSize, EncodableSync,
     RelativeDecodable, RelativeDecodableCanonic, RelativeEncodable, RelativeEncodableKnownSize,
 };
-use willow_data_model::{grouping::Area, Entry, PayloadDigest};
+use willow_data_model::{grouping::Area, Entry, PayloadDigest, TrustedRelativeDecodable};
 use willow_encoding::is_bitflagged;
 
 /// Returned when an operation only applicable to a capability with access mode [`AccessMode::Write`] was called on a capability with access mode [`AccessMode::Read`].
@@ -596,6 +596,121 @@ where
         }
 
         1 + namespace_len + progenitor_len + init_auth_len + delegations_count_len + delegations_len
+    }
+}
+
+impl<
+        const MCL: usize,
+        const MCC: usize,
+        const MPL: usize,
+        NamespacePublicKey,
+        NamespaceSignature,
+        UserPublicKey,
+        UserSignature,
+    > TrustedRelativeDecodable<Area<MCL, MCC, MPL, UserPublicKey>>
+    for McCapability<
+        MCL,
+        MCC,
+        MPL,
+        NamespacePublicKey,
+        NamespaceSignature,
+        UserPublicKey,
+        UserSignature,
+    >
+where
+    NamespacePublicKey: McNamespacePublicKey + Verifier<NamespaceSignature>,
+    UserPublicKey: McPublicUserKey<UserSignature>,
+    NamespaceSignature: EncodableSync + EncodableKnownSize + Clone + Decodable,
+    UserSignature: EncodableSync + EncodableKnownSize + Clone + Decodable,
+
+    Blame: From<NamespacePublicKey::ErrorReason>
+        + From<UserPublicKey::ErrorReason>
+        + From<UserPublicKey::ErrorCanonic>
+        + From<NamespaceSignature::ErrorReason>
+        + From<UserSignature::ErrorReason>,
+{
+    /// Unsafely decode a [`McCapability`] from a [`BulkProducer`] of bytes, that is, decode without verifying the validity of the inner capability.
+    ///
+    /// # Safety
+    /// Only use this method to decode [`McCapability`] from trusted sources, e.g. a database you yourself are writing verified capabilities to.
+    async unsafe fn trusted_relative_decode<P>(
+        producer: &mut P,
+        r: &Area<MCL, MCC, MPL, UserPublicKey>,
+    ) -> Result<Self, ufotofu_codec::DecodeError<P::Final, P::Error, Blame>>
+    where
+        P: ufotofu::BulkProducer<Item = u8>,
+    {
+        let header = producer.produce_item().await?;
+
+        let is_owned = is_bitflagged(header, 0);
+        let access_mode = if is_bitflagged(header, 1) {
+            AccessMode::Write
+        } else {
+            AccessMode::Read
+        };
+
+        let namespace_key = NamespacePublicKey::decode(producer)
+            .await
+            .map_err(DecodeError::map_other_from)?;
+        let user_key = UserPublicKey::decode(producer)
+            .await
+            .map_err(DecodeError::map_other_from)?;
+
+        let initial_authorisation = if is_owned {
+            Some(
+                NamespaceSignature::decode(producer)
+                    .await
+                    .map_err(DecodeError::map_other_from)?,
+            )
+        } else {
+            None
+        };
+
+        let tag = Tag::from_raw(header, TagWidth::six(), 2);
+
+        let delegations_to_decode = CompactU64::relative_decode(producer, &tag)
+            .await
+            .map_err(DecodeError::map_other_from)?
+            .0;
+
+        let mut prev_area = r.clone();
+        let mut delegations = Vec::new();
+
+        for _ in 0..delegations_to_decode {
+            let area =
+                Area::<MCL, MCC, MPL, UserPublicKey>::relative_decode(producer, &prev_area).await?;
+            prev_area = area.clone();
+            let user = UserPublicKey::decode(producer)
+                .await
+                .map_err(DecodeError::map_other_from)?;
+            let signature = UserSignature::decode(producer)
+                .await
+                .map_err(DecodeError::map_other_from)?;
+
+            delegations.push(Delegation::new(area, user, signature))
+        }
+
+        let cap = match initial_authorisation {
+            Some(init_auth) => unsafe {
+                McCapability::Owned(OwnedCapability::new_unchecked(
+                    access_mode,
+                    namespace_key,
+                    user_key,
+                    init_auth,
+                    delegations,
+                ))
+            },
+            None => unsafe {
+                McCapability::Communal(CommunalCapability::new_unchecked(
+                    access_mode,
+                    namespace_key,
+                    user_key,
+                    delegations,
+                ))
+            },
+        };
+
+        Ok(cap)
     }
 }
 

--- a/meadowcap/src/owned_capability.rs
+++ b/meadowcap/src/owned_capability.rs
@@ -182,8 +182,8 @@ where
 
         let handover = OwnedHandover {
             cap: self,
-            area: &new_area,
-            user: &new_user,
+            area: new_area,
+            user: new_user,
         };
 
         let handover_enc = handover.sync_encode_into_boxed_slice();
@@ -248,8 +248,8 @@ where
 
         let handover = OwnedHandover {
             cap: self,
-            area: &new_area,
-            user: &new_user,
+            area: new_area,
+            user: new_user,
         };
 
         let handover_enc = handover.sync_encode_into_boxed_slice();
@@ -341,6 +341,25 @@ where
     pub fn initial_authorisation(&self) -> &NamespaceSignature {
         &self.initial_authorisation
     }
+
+    /// Returns a [`OwnedCapability`] without checking if its initial authorisation or delegations are valid.
+    ///
+    /// Calling this method with an invalid initial authorisation or delegation is immediate undefined behaviour!
+    pub unsafe fn new_unchecked(
+        access_mode: AccessMode,
+        namespace_key: NamespacePublicKey,
+        user_key: UserPublicKey,
+        initial_authorisation: NamespaceSignature,
+        delegations: Vec<Delegation<MCL, MCC, MPL, UserPublicKey, UserSignature>>,
+    ) -> Self {
+        Self {
+            access_mode,
+            namespace_key,
+            user_key,
+            initial_authorisation,
+            delegations,
+        }
+    }
 }
 
 struct OwnedInitialAuthorisationMsg<'a, UserPublicKey>
@@ -351,7 +370,7 @@ where
     user_key: &'a UserPublicKey,
 }
 
-impl<'a, UserPublicKey> Encodable for OwnedInitialAuthorisationMsg<'a, UserPublicKey>
+impl<UserPublicKey> Encodable for OwnedInitialAuthorisationMsg<'_, UserPublicKey>
 where
     UserPublicKey: SubspaceId + Encodable,
 {
@@ -371,7 +390,7 @@ where
     }
 }
 
-impl<'a, UserPublicKey> EncodableKnownSize for OwnedInitialAuthorisationMsg<'a, UserPublicKey>
+impl<UserPublicKey> EncodableKnownSize for OwnedInitialAuthorisationMsg<'_, UserPublicKey>
 where
     UserPublicKey: SubspaceId + EncodableKnownSize,
 {
@@ -380,7 +399,7 @@ where
     }
 }
 
-impl<'a, UserPublicKey> EncodableSync for OwnedInitialAuthorisationMsg<'a, UserPublicKey> where
+impl<UserPublicKey> EncodableSync for OwnedInitialAuthorisationMsg<'_, UserPublicKey> where
     UserPublicKey: SubspaceId + EncodableKnownSize
 {
 }
@@ -417,7 +436,6 @@ pub struct OwnedHandover<
 }
 
 impl<
-        'a,
         const MCL: usize,
         const MCC: usize,
         const MPL: usize,
@@ -427,7 +445,7 @@ impl<
         UserSignature,
     > Encodable
     for OwnedHandover<
-        'a,
+        '_,
         MCL,
         MCC,
         MPL,
@@ -470,7 +488,6 @@ where
 }
 
 impl<
-        'a,
         const MCL: usize,
         const MCC: usize,
         const MPL: usize,
@@ -480,7 +497,7 @@ impl<
         UserSignature,
     > EncodableKnownSize
     for OwnedHandover<
-        'a,
+        '_,
         MCL,
         MCC,
         MPL,
@@ -511,7 +528,7 @@ where
         let prev_area = last_delegation.area();
         let prev_signature = last_delegation.signature();
 
-        let area_len = self.area.relative_len_of_encoding(&prev_area);
+        let area_len = self.area.relative_len_of_encoding(prev_area);
         let prev_sig_len = prev_signature.len_of_encoding();
         let user_len = self.user.len_of_encoding();
 
@@ -520,7 +537,6 @@ where
 }
 
 impl<
-        'a,
         const MCL: usize,
         const MCC: usize,
         const MPL: usize,
@@ -530,7 +546,7 @@ impl<
         UserSignature,
     > EncodableSync
     for OwnedHandover<
-        'a,
+        '_,
         MCL,
         MCC,
         MPL,

--- a/willow_25/Cargo.toml
+++ b/willow_25/Cargo.toml
@@ -17,6 +17,8 @@ rand = "0.8.5"
 signature = "2.2.0"
 blake3 = "1.8.0"
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
+compact_u64 = { path = "../compact_u64", features = [ "std", "dev" ] }
+willow-encoding = { path = "../encoding", version = "0.1.0" }
 
 [lints]
 workspace = true

--- a/willow_25/src/authorisation_token.rs
+++ b/willow_25/src/authorisation_token.rs
@@ -1,5 +1,13 @@
-use meadowcap::McAuthorisationToken;
-use willow_data_model::AuthorisationToken;
+use compact_u64::{CompactU64, Tag, TagWidth};
+use meadowcap::{
+    AccessMode, CommunalCapability, Delegation, McAuthorisationToken, McCapability, OwnedCapability,
+};
+use ufotofu_codec::{
+    Blame, Decodable, DecodeError, Encodable, EncodableKnownSize, EncodableSync, RelativeDecodable,
+    RelativeEncodable, RelativeEncodableKnownSize,
+};
+use willow_data_model::{grouping::Area, AuthorisationToken, TrustedDecodable};
+use willow_encoding::is_bitflagged;
 
 #[derive(Clone, Debug)]
 pub struct AuthorisationToken25(
@@ -73,5 +81,43 @@ impl
         >,
     ) -> bool {
         self.0.is_authorised_write(entry)
+    }
+}
+
+impl Encodable for AuthorisationToken25 {
+    async fn encode<C>(&self, consumer: &mut C) -> Result<(), C::Error>
+    where
+        C: ufotofu::BulkConsumer<Item = u8>,
+    {
+        self.0.capability.relative_encode(consumer).await?;
+        self.0.signature.encode(consumer).await?;
+
+        Ok(())
+    }
+}
+
+impl TrustedDecodable for AuthorisationToken25 {
+    async unsafe fn trusted_decode<P>(
+        producer: &mut P,
+    ) -> Result<Self, ufotofu_codec::DecodeError<P::Final, P::Error, Blame>>
+    where
+        P: ufotofu::BulkProducer<Item = u8>,
+    {
+        let capability = McCapability::<
+            1024,
+            1024,
+            1024,
+            crate::NamespaceId25,
+            crate::Signature25,
+            crate::SubspaceId25,
+            crate::Signature25,
+        >::trusted_relative_decode(producer, Area::new_full())
+        .await;
+        let signature = crate::Signature25::decode(consumer).await?;
+
+        Ok(Self(McAuthorisationToken {
+            capability,
+            signature,
+        }))
     }
 }

--- a/willow_25/src/signature.rs
+++ b/willow_25/src/signature.rs
@@ -1,4 +1,6 @@
-use ufotofu_codec::{Blame, Decodable, Encodable, EncodableKnownSize, EncodableSync};
+use ufotofu_codec::{
+    Blame, Decodable, DecodableCanonic, Encodable, EncodableKnownSize, EncodableSync,
+};
 
 #[cfg(feature = "dev")]
 use arbitrary::Arbitrary;
@@ -48,12 +50,26 @@ impl Decodable for Signature25 {
     {
         let mut slice: [u8; 64] = [0; 64];
 
-        producer.bulk_overwrite_full_slice(&mut slice).await;
+        producer.bulk_overwrite_full_slice(&mut slice).await?;
 
         // We can unwrap here because we know the slice is 64 bytes
         let sig = ed25519_dalek::Signature::from_bytes(&slice);
 
         Ok(Self(sig))
+    }
+}
+
+impl DecodableCanonic for Signature25 {
+    type ErrorCanonic = Blame;
+
+    async fn decode_canonic<P>(
+        producer: &mut P,
+    ) -> Result<Self, ufotofu_codec::DecodeError<P::Final, P::Error, Self::ErrorCanonic>>
+    where
+        P: ufotofu::BulkProducer<Item = u8>,
+        Self: Sized,
+    {
+        Self::decode(producer).await
     }
 }
 


### PR DESCRIPTION
Wanted these for situations where you can decode items which you trust are valid (e.g. a verifiable signature) beforehand (e.g. because you encoded the data yourself).

Concrete use case being decoding authorisation tokens from a sled store without validating all their signatures each time.

