### PR TITLE
Add Path::from_slices helper function

### DIFF
--- a/data-model/src/path/mod.rs
+++ b/data-model/src/path/mod.rs
@@ -536,17 +536,64 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> Path<MCL, MCC, MPL> {
     }
 
     /// Create a new path from a slice over byte slices.
-    pub fn from_slices<T: AsRef<[u8]>>(slices: &[T]) -> Result<Self, InvalidPathError> {
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use willow_data_model::{Path, PathConstructionError, InvalidPathError};
+    /// // Ok
+    /// let path = Path::<12, 3, 30>::from_slices(&["alfie", "notes"]).unwrap();
+    ///
+    /// // Err
+    /// let result1 = Path::<12, 3, 30>::from_slices(&["themaxpathlengthis30andthisistoolong"]);
+    /// assert!(matches!(result1, Err(PathConstructionError::InvalidPath(InvalidPathError::PathTooLong))));
+    ///
+    /// // Err
+    /// let result2 = Path::<12, 3, 30>::from_slices(&["too", "many", "components", "error"]);
+    /// assert!(matches!(result2, Err(PathConstructionError::InvalidPath(InvalidPathError::TooManyComponents))));
+    ///
+    /// // Err
+    /// let result3 = Path::<12, 3, 30>::from_slices(&["overencumbered"]);
+    /// assert!(matches!(result3, Err(PathConstructionError::ComponentTooLongError)));
+    /// ```
+    pub fn from_slices<T: AsRef<[u8]>>(slices: &[T]) -> Result<Self, PathConstructionError> {
         let total_length = slices.iter().map(|it| it.as_ref().len()).sum();
         let mut builder = PathBuilder::new(total_length, slices.len())?;
 
         for component_slice in slices {
             let component = Component::<MCL>::new(component_slice.as_ref())
-                .ok_or(InvalidPathError::ComponentTooLong)?;
+                .ok_or(PathConstructionError::ComponentTooLongError)?;
             builder.append_component(component);
         }
 
         Ok(builder.build())
+    }
+}
+
+/// Raised upon failing to construct a [`Path`] from a slice of slices.
+#[derive(Debug, Clone)]
+pub enum PathConstructionError {
+    InvalidPath(InvalidPathError),
+    ComponentTooLongError,
+}
+
+impl std::error::Error for PathConstructionError {}
+impl std::fmt::Display for PathConstructionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PathConstructionError::InvalidPath(invalid_path_error) => {
+                std::fmt::Display::fmt(invalid_path_error, f)
+            }
+            PathConstructionError::ComponentTooLongError => {
+                write!(f, "failed to construct a `Path` from slices")
+            }
+        }
+    }
+}
+
+impl From<InvalidPathError> for PathConstructionError {
+    fn from(value: InvalidPathError) -> Self {
+        Self::InvalidPath(value)
     }
 }
 

--- a/data-model/src/path/mod.rs
+++ b/data-model/src/path/mod.rs
@@ -549,7 +549,7 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> Path<MCL, MCC, MPL> {
     /// let path = Path::<12, 3, 30>::from_slices(&["alfie", "notes"]).unwrap();
     ///
     /// // Err
-    /// let result1 = Path::<12, 3, 30>::from_slices(&["themaxpathlengthis30andthisistoolong"]);
+    /// let result1 = Path::<12, 3, 30>::from_slices(&["themaxpath", "lengthis30", "thisislonger"]);
     /// assert!(matches!(result1, Err(PathConstructionError::InvalidPath(InvalidPathError::PathTooLong))));
     ///
     /// // Err
@@ -589,7 +589,7 @@ impl std::fmt::Display for PathConstructionError {
                 std::fmt::Display::fmt(invalid_path_error, f)
             }
             PathConstructionError::ComponentTooLongError => {
-                write!(f, "failed to construct a `Path` from slices")
+                write!(f, "Length of a path component in bytes exceeded the maximum component length"")
             }
         }
     }

--- a/data-model/src/path/mod.rs
+++ b/data-model/src/path/mod.rs
@@ -534,6 +534,20 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> Path<MCL, MCC, MPL> {
 
         None
     }
+
+    /// Create a new path from a slice over byte slices.
+    pub fn from_slices<T: AsRef<[u8]>>(slices: &[T]) -> Result<Self, InvalidPathError> {
+        let total_length = slices.iter().map(|it| it.as_ref().len()).sum();
+        let mut builder = PathBuilder::new(total_length, slices.len())?;
+
+        for component_slice in slices {
+            let component = Component::<MCL>::new(component_slice.as_ref())
+                .ok_or(InvalidPathError::ComponentTooLong)?;
+            builder.append_component(component);
+        }
+
+        Ok(builder.build())
+    }
 }
 
 impl<const MCL: usize, const MCC: usize, const MPL: usize> PartialEq for Path<MCL, MCC, MPL> {

--- a/data-model/src/path/mod.rs
+++ b/data-model/src/path/mod.rs
@@ -535,7 +535,11 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize> Path<MCL, MCC, MPL> {
         None
     }
 
-    /// Create a new path from a slice over byte slices.
+    /// Create a new path from a slice of byte slices.
+    ///
+    /// #### Complexity
+    ///
+    /// Runs in `O(n + m)`, where `n` is the total length of the path in bytes, and `m` is the number of components. Performs a single allocation of `O(n + m)` bytes.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Tackling part of https://github.com/earthstar-project/willow-rs/issues/56

I went with `Path::from_slices` rather than separate `Path::from_{bytes,strs}` because I didn't want to duplicate the logic, but there wasn't really a clean way to implement one in terms of another because even though `&str` can dereference to `&[u8]`, it's not possible to convert `&[&str]` to `&[&[u8]]` without allocating or transmuting (as far as I could see).

I saw that other methods have a `#### Complexity` section but I didn't feel confident in determining what the total complexity was because I can't quite tell how `append_component` behaves (complexity-speaking).

Also let me know if or where the best place to add a unit test for this would be!

I'm running late for something so I'll drop this and check back later!