### PR TITLE
Store.payload returns Payload enum

### DIFF
--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -292,7 +292,7 @@ pub struct QueryIgnoreParams {
 pub enum Payload<E, P: BulkProducer<Item = u8, Final = (), Error = E>> {
     /// A payload for which all bytes are available locally.
     Complete(P),
-    /// A payload for which fewer bytes than the known length of the payload are available locally.
+    /// A payload for which fewer bytes than the known length of the payload are available locally (at the time at which the store was queried). If the payload becomes fully available before the user code has exhausted the producer, then this variant might indeed yield the complete payload despite its name.
     Incomplete(P),
 }
 

--- a/data-model/src/store.rs
+++ b/data-model/src/store.rs
@@ -288,6 +288,14 @@ pub struct QueryIgnoreParams {
     pub ignore_empty_payloads: bool,
 }
 
+/// A payload associated with an [`Entry`].
+pub enum Payload<E, P: BulkProducer<Item = u8, Final = (), Error = E>> {
+    /// A payload for which all bytes are available locally.
+    Complete(P),
+    /// A payload for which fewer bytes than the known length of the payload are available locally.
+    Incomplete(P),
+}
+
 impl QueryIgnoreParams {
     // An entry for which no payload bytes are available.
     fn ignores_fresh_entry<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD>(
@@ -455,7 +463,7 @@ pub trait Store<const MCL: usize, const MCC: usize, const MPL: usize, N, S, PD, 
         expected_digest: Option<PD>,
     ) -> impl Future<
         Output = Result<
-            impl BulkProducer<Item = u8, Final = (), Error = Self::Error>,
+            Payload<Self::Error, impl BulkProducer<Item = u8, Final = (), Error = Self::Error>>,
             PayloadError<Self::Error>,
         >,
     >;

--- a/fuzz/src/store_events.rs
+++ b/fuzz/src/store_events.rs
@@ -16,7 +16,7 @@ use crate::{
 use either::Either::{Left, Right};
 use ufotofu::{producer::FromSlice, Producer};
 use willow_data_model::{
-    grouping::Area, LengthyAuthorisedEntry, QueryIgnoreParams, Store, StoreEvent,
+    grouping::Area, LengthyAuthorisedEntry, Payload, QueryIgnoreParams, Store, StoreEvent,
 };
 
 /// A function for testing whether a store correctly emits events. Panics if it doesn't.
@@ -194,7 +194,8 @@ pub fn check_store_events(
                                         )
                                         .await
                                     {
-                                        Ok(new_payload_bytes_producer) => {
+                                        Ok(Payload::Complete(new_payload_bytes_producer))
+                                        | Ok(Payload::Incomplete(new_payload_bytes_producer)) => {
                                             let mut limited = ufotofu::producer::Limit::new(
                                                 new_payload_bytes_producer,
                                                 (now_available - previous_available) as usize,


### PR DESCRIPTION
- Adds `Payload` enum with complete and incomplete variants
- Returns this enum from `Store.payload`
- Update StoreSimpleSled and ControlStore to satisfy trait
- Update testing tools to handle variants