### PR TITLE
AreaMap + NamespaceAreaMap

### DIFF
--- a/data-model/src/grouping/area.rs
+++ b/data-model/src/grouping/area.rs
@@ -520,6 +520,73 @@ where
     }
 }
 
+pub struct NamespacedAreaMap<const MCL: usize, const MCC: usize, const MPL: usize, N, S, T>
+where
+    N: Clone + Eq + std::hash::Hash,
+    S: Clone + Eq + std::hash::Hash,
+{
+    namespaces: HashMap<N, AreaMap<MCL, MCC, MPL, S, T>>,
+}
+
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, T> Default
+    for NamespacedAreaMap<MCL, MCC, MPL, N, S, T>
+where
+    N: Clone + Eq + std::hash::Hash,
+    S: Clone + Eq + std::hash::Hash,
+{
+    fn default() -> Self {
+        Self {
+            namespaces: HashMap::new(),
+        }
+    }
+}
+
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S, T>
+    NamespacedAreaMap<MCL, MCC, MPL, N, S, T>
+where
+    N: Clone + Eq + std::hash::Hash,
+    S: Clone + Eq + std::hash::Hash,
+{
+    /// Insert a new value along with its associated NamespaceId and [`Area`].
+    pub fn insert(&mut self, namespace: &N, area: &Area<MCL, MCC, MPL, S>, value: T) {
+        match self.namespaces.get_mut(namespace) {
+            Some(area_map) => {
+                area_map.insert(area, value);
+            }
+            None => {
+                let mut area_map: AreaMap<MCL, MCC, MPL, S, T> = AreaMap::default();
+                area_map.insert(area, value);
+
+                self.namespaces.insert(namespace.clone(), area_map);
+            }
+        }
+    }
+
+    /// Retrieve all values with namespaced [`Area`]s which intersect with the given namespaced [`Area`].
+    pub fn intersecting_values(
+        &self,
+        namespace: &N,
+        area: &Area<MCL, MCC, MPL, S>,
+    ) -> Option<Vec<&T>> {
+        match self.namespaces.get(namespace) {
+            Some(area_map) => area_map.intersecting_values(area),
+            None => None,
+        }
+    }
+
+    /// Retrieve all values and their namespaced [`Area`]s which intersect with the given namespaced [`Area`].
+    pub fn intersecting_pairs(
+        &self,
+        namespace: &N,
+        area: &Area<MCL, MCC, MPL, S>,
+    ) -> Option<Vec<(Area<MCL, MCC, MPL, S>, &T)>> {
+        match self.namespaces.get(namespace) {
+            Some(area_map) => area_map.intersecting_pairs(area),
+            None => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/data-model/src/grouping/area.rs
+++ b/data-model/src/grouping/area.rs
@@ -350,6 +350,7 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, S, T> AreaMap<MCL, MC
 where
     S: Clone + Eq + std::hash::Hash,
 {
+    /// Insert a new value along with its associated [`Area`].
     pub fn insert(&mut self, area: &Area<MCL, MCC, MPL, S>, value: T) {
         match self.subspaces.get_mut(&area.subspace) {
             Some(subspace_map) => match subspace_map.get_mut(area.path()) {
@@ -377,6 +378,7 @@ where
         };
     }
 
+    /// Retrieve all values with [`Area`]s which intersect with the given [`Area`].
     pub fn intersecting_values(&self, area: &Area<MCL, MCC, MPL, S>) -> Option<Vec<&T>> {
         match area.subspace() {
             AreaSubspace::Any => {
@@ -421,6 +423,87 @@ where
                             for (times, value) in values {
                                 if let Some(_intersection) = times.intersection(area.times()) {
                                     values_vec.push(value)
+                                }
+                            }
+                        }
+                    }
+                };
+
+                if values_vec.is_empty() {
+                    None
+                } else {
+                    Some(values_vec)
+                }
+            }
+        }
+    }
+
+    /// Retrieve all values and their [`Area`]s which intersect with the given [`Area`].
+    pub fn intersecting_pairs(
+        &self,
+        area: &Area<MCL, MCC, MPL, S>,
+    ) -> Option<Vec<(Area<MCL, MCC, MPL, S>, &T)>> {
+        match area.subspace() {
+            AreaSubspace::Any => {
+                let mut values_vec = Vec::new();
+
+                for (area_subspace, subspace_map) in &self.subspaces {
+                    for (path, values) in subspace_map {
+                        if area.path().is_related(path) {
+                            for (times, value) in values {
+                                if let Some(_intersection) = times.intersection(area.times()) {
+                                    let area = Area {
+                                        subspace: area_subspace.clone(),
+                                        path: path.clone(),
+                                        times: *times,
+                                    };
+
+                                    values_vec.push((area, value))
+                                }
+                            }
+                        }
+                    }
+                }
+                Some(values_vec)
+            }
+            AreaSubspace::Id(_area_subspace) => {
+                let mut values_vec = Vec::new();
+
+                if let Some(subspace_map) = self.subspaces.get(&AreaSubspace::Any) {
+                    for (path, values) in subspace_map {
+                        //println!("hello");
+
+                        if area.path().is_related(path) {
+                            //println!("bello");
+
+                            for (times, value) in values {
+                                //println!("cello");
+                                if let Some(_intersection) = times.intersection(area.times()) {
+                                    let area = Area {
+                                        subspace: AreaSubspace::Any,
+                                        path: path.clone(),
+                                        times: *times,
+                                    };
+
+                                    values_vec.push((area, value))
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let Some(subspace_map) = self.subspaces.get(area.subspace()) {
+                    for (path, values) in subspace_map {
+                        if area.path().is_related(path) {
+                            for (times, value) in values {
+                                if let Some(_intersection) = times.intersection(area.times()) {
+                                    let area = Area {
+                                        subspace: area.subspace().clone(),
+                                        path: path.clone(),
+                                        times: *times,
+                                    };
+
+                                    values_vec.push((area, value))
                                 }
                             }
                         }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -444,3 +444,10 @@ path = "fuzz_targets/transport_encryption.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "area_map"
+path = "fuzz_targets/area_map.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -451,3 +451,10 @@ path = "fuzz_targets/area_map.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "namespaced_area_map"
+path = "fuzz_targets/namespaced_area_map.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/area_map.rs
+++ b/fuzz/fuzz_targets/area_map.rs
@@ -1,0 +1,42 @@
+#![no_main]
+
+use std::collections::HashMap;
+
+use libfuzzer_sys::fuzz_target;
+use willow_data_model::grouping::{Area, AreaMap};
+use willow_fuzz::placeholder_params::FakeSubspaceId;
+
+fuzz_target!(|data: (
+    Area<16, 16, 16, FakeSubspaceId>,
+    HashMap<u64, Area<16, 16, 16, FakeSubspaceId>>
+)| {
+    let (query_area, insertions) = data;
+
+    let mut area_map = AreaMap::<16, 16, 16, FakeSubspaceId, u64>::default();
+
+    for (value, area) in insertions.clone() {
+        area_map.insert(&area, value);
+    }
+
+    match area_map.intersecting_values(&query_area) {
+        Some(values) => {
+            for value in values {
+                match insertions.get(value) {
+                    Some(area) => {
+                        if area.intersection(&query_area).is_none() {
+                            panic!("Query area did not intersect with value area. Value area: {area:?}, Query area: {query_area:?}");
+                        }
+                    }
+                    None => panic!("A value which shouldn't be here appeared"),
+                }
+            }
+        }
+        None => {
+            for (value, area) in insertions {
+                if let Some(_intersection) = area.intersection(&query_area) {
+                    panic!("Result was missing from AreaMap::intersecting_values: value {:?}, area: {:?}, query: {:?}", value, area, query_area)
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/area_map.rs
+++ b/fuzz/fuzz_targets/area_map.rs
@@ -32,6 +32,33 @@ fuzz_target!(|data: (
             }
         }
         None => {
+            for (value, area) in &insertions {
+                if let Some(_intersection) = area.intersection(&query_area) {
+                    panic!("Result was missing from AreaMap::intersecting_values: value {:?}, area: {:?}, query: {:?}", value, area, query_area)
+                }
+            }
+        }
+    }
+
+    match area_map.intersecting_pairs(&query_area) {
+        Some(values) => {
+            for (area, value) in values {
+                match area.intersection(&query_area) {
+                    Some(_) => {}
+                    None => {
+                        panic!("Query area did not intersect with value area. Value area: {area:?}, Query area: {query_area:?}");
+                    }
+                }
+
+                match insertions.get(value) {
+                    Some(og_area) => {
+                        assert_eq!(&area, og_area);
+                    }
+                    None => panic!("A value which shouldn't be here appeared"),
+                }
+            }
+        }
+        None => {
             for (value, area) in insertions {
                 if let Some(_intersection) = area.intersection(&query_area) {
                     panic!("Result was missing from AreaMap::intersecting_values: value {:?}, area: {:?}, query: {:?}", value, area, query_area)

--- a/fuzz/fuzz_targets/namespaced_area_map.rs
+++ b/fuzz/fuzz_targets/namespaced_area_map.rs
@@ -1,0 +1,78 @@
+#![no_main]
+
+use std::collections::HashMap;
+
+use libfuzzer_sys::fuzz_target;
+use willow_data_model::grouping::{Area, NamespacedAreaMap};
+use willow_fuzz::placeholder_params::{FakeNamespaceId, FakeSubspaceId};
+
+fuzz_target!(|data: (
+    (FakeNamespaceId, Area<16, 16, 16, FakeSubspaceId>),
+    HashMap<u64, (FakeNamespaceId, Area<16, 16, 16, FakeSubspaceId>)>
+)| {
+    let (namespaced_query_area, insertions) = data;
+
+    let mut namespaced_area_map =
+        NamespacedAreaMap::<16, 16, 16, FakeNamespaceId, FakeSubspaceId, u64>::default();
+
+    for (value, (namespace, area)) in insertions.clone() {
+        namespaced_area_map.insert(&namespace, &area, value);
+    }
+
+    let (query_namespace, query_area) = namespaced_query_area;
+
+    match namespaced_area_map.intersecting_values(&query_namespace, &query_area) {
+        Some(values) => {
+            for value in values {
+                match insertions.get(value) {
+                    Some((namespace, area)) => {
+                        if namespace != &query_namespace {
+                            panic!("Query area did not belong to namespace")
+                        }
+
+                        if area.intersection(&query_area).is_none() {
+                            panic!("Query area did not intersect with value area. Value area: {area:?}, Query area: {query_area:?}");
+                        }
+                    }
+                    None => panic!("A value which shouldn't be here appeared"),
+                }
+            }
+        }
+        None => {
+            for (value, (namespace, area)) in &insertions {
+                if namespace == &query_namespace {
+                    if let Some(_intersection) = area.intersection(&query_area) {
+                        panic!("Result was missing from AreaMap::intersecting_values: value {:?}, area: {:?}, query: {:?}", value, area, query_area)
+                    }
+                }
+            }
+        }
+    }
+
+    match namespaced_area_map.intersecting_pairs(&query_namespace, &query_area) {
+        Some(values) => {
+            for (area, value) in values {
+                if area.intersection(&query_area).is_none() {
+                    panic!("Query area did not intersect with value area. Value area: {area:?}, Query area: {query_area:?}");
+                }
+
+                match insertions.get(value) {
+                    Some((og_namespace, og_area)) => {
+                        assert_eq!(&query_namespace, og_namespace);
+                        assert_eq!(&area, og_area);
+                    }
+                    None => panic!("A value which shouldn't be here appeared"),
+                }
+            }
+        }
+        None => {
+            for (value, (namespace, area)) in insertions {
+                if namespace == query_namespace {
+                    if let Some(_intersection) = area.intersection(&query_area) {
+                        panic!("Result was missing from AreaMap::intersecting_values: value {:?}, area: {:?}, query: {:?}", value, area, query_area)
+                    }
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
Two new structs which allow you to store anything relative to an area, and then query back any stored things which intersect with a given area.

- AreaMap stores every item with a value of `T` along with an `Area`
- NamespacedAreaMap stores every item with a value of `T` along with an `Area` *and* `NamespaceId`.