### PR TITLE
Generics refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "cfe61992c4cb9ec764c74faebcec021b1e112a785c413431799052d1c05ee47f"
 dependencies = [
  "arbitrary",
  "either",
- "ufotofu",
+ "ufotofu 0.6.7",
  "ufotofu_codec",
  "ufotofu_codec_endian",
 ]
@@ -653,10 +653,10 @@ dependencies = [
  "either",
  "futures",
  "smol",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
  "ufotofu_codec_endian",
- "ufotofu_queues",
+ "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wb_async_utils",
  "willow-encoding",
 ]
@@ -707,7 +707,7 @@ dependencies = [
  "compact_u64",
  "either",
  "signature",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
  "willow-data-model",
  "willow-encoding",
@@ -1161,22 +1161,35 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ufotofu"
-version = "0.6.6"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df1ac34770637a020a951ea1736f0a97af311fc4723b0c4b46daa43293f7a2"
+dependencies = [
+ "either",
+ "futures",
+ "pin-project",
+ "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ufotofu"
+version = "0.7.0"
 dependencies = [
  "arbitrary",
  "either",
  "futures",
  "pin-project",
+ "ufotofu_queues 0.6.0",
 ]
 
 [[package]]
 name = "ufotofu_codec"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arbitrary",
  "either",
  "pollster",
- "ufotofu",
+ "ufotofu 0.7.0",
  "wb_async_utils",
 ]
 
@@ -1188,9 +1201,13 @@ checksum = "4cb93cb00d9ae0a3d7ba45f779de03faf8aab584c68b4d4266b3377fa90d027d"
 dependencies = [
  "arbitrary",
  "either",
- "ufotofu",
+ "ufotofu 0.6.7",
  "ufotofu_codec",
 ]
+
+[[package]]
+name = "ufotofu_queues"
+version = "0.6.0"
 
 [[package]]
 name = "ufotofu_queues"
@@ -1227,14 +1244,14 @@ dependencies = [
 
 [[package]]
 name = "wb_async_utils"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde870d22fde63569d9c9ded9b811ac2f5f70f28019c7a1a28cb8bd3c44e3c6c"
+checksum = "29d07b9a0090d19edefbe07a6f7b19e7ba3f883dc2ef69f31e4edcb366b36ad8"
 dependencies = [
  "either",
  "fairly_unsafe_cell",
- "ufotofu",
- "ufotofu_queues",
+ "ufotofu 0.7.0",
+ "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1249,9 +1266,9 @@ dependencies = [
  "lcmux",
  "multimap",
  "smol",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
- "ufotofu_queues",
+ "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wb_async_utils",
  "willow-data-model",
  "willow-encoding",
@@ -1270,7 +1287,7 @@ dependencies = [
  "either",
  "slab",
  "smol",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
  "ufotofu_codec_endian",
  "wb_async_utils",
@@ -1280,11 +1297,6 @@ dependencies = [
 [[package]]
 name = "willow-encoding"
 version = "0.1.0"
-dependencies = [
- "either",
- "pollster",
- "ufotofu",
-]
 
 [[package]]
 name = "willow-fuzz"
@@ -1301,10 +1313,10 @@ dependencies = [
  "sled",
  "syncify",
  "tempdir",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
  "ufotofu_codec_endian",
- "ufotofu_queues",
+ "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wb_async_utils",
  "wgps",
  "willow-data-model",
@@ -1322,7 +1334,7 @@ dependencies = [
  "arbitrary",
  "compact_u64",
  "pollster",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
  "willow-data-model",
  "willow-encoding",
@@ -1334,10 +1346,10 @@ version = "0.1.0"
 dependencies = [
  "either",
  "sled",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
  "ufotofu_codec_endian",
- "ufotofu_queues",
+ "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wb_async_utils",
  "willow-data-model",
  "willow_25",
@@ -1350,9 +1362,9 @@ dependencies = [
  "either",
  "futures",
  "smol",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
- "ufotofu_queues",
+ "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wb_async_utils",
 ]
 
@@ -1367,7 +1379,7 @@ dependencies = [
  "meadowcap",
  "rand 0.8.5",
  "signature",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
  "willow-data-model",
  "willow-encoding",
@@ -1380,7 +1392,7 @@ dependencies = [
  "arbitrary",
  "meadowcap",
  "pollster",
- "ufotofu",
+ "ufotofu 0.7.0",
  "ufotofu_codec",
  "willow-data-model",
  "willow_25",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +34,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -51,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
 dependencies = [
  "async-lock",
  "blocking",
@@ -62,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -75,7 +84,6 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "tracing",
  "windows-sys",
 ]
 
@@ -103,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
  "async-channel",
  "async-io",
@@ -117,14 +125,13 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix",
- "tracing",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -146,9 +153,12 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async_cell"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834eee9ce518130a3b4d5af09ecc43e9d6b57ee76613f227a1ddd6b77c7a62bc"
+checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -158,15 +168,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
@@ -176,9 +186,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blake3"
@@ -204,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -229,9 +239,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
@@ -240,19 +250,17 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "compact_u64"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe61992c4cb9ec764c74faebcec021b1e112a785c413431799052d1c05ee47f"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "either",
- "ufotofu 0.6.7",
+ "ufotofu",
  "ufotofu_codec",
  "ufotofu_codec_endian",
 ]
@@ -289,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -391,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -412,9 +420,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys",
@@ -587,6 +595,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,14 +626,14 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -621,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "instant"
@@ -640,9 +662,15 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lcmux"
@@ -653,7 +681,7 @@ dependencies = [
  "either",
  "futures",
  "smol",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "ufotofu_codec_endian",
  "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -663,15 +691,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
 dependencies = [
  "arbitrary",
  "cc",
@@ -679,15 +707,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -700,6 +728,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "meadowcap"
 version = "0.2.0"
 dependencies = [
@@ -707,7 +757,7 @@ dependencies = [
  "compact_u64",
  "either",
  "signature",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "willow-data-model",
  "willow-encoding",
@@ -716,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "multimap"
@@ -728,6 +778,28 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -815,16 +887,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "tracing",
  "windows-sys",
 ]
 
@@ -863,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -944,6 +1015,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,16 +1078,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1018,6 +1145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,12 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "sled"
@@ -1068,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol"
@@ -1107,9 +1240,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1138,6 +1271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,27 +1291,48 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "ufotofu"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df1ac34770637a020a951ea1736f0a97af311fc4723b0c4b46daa43293f7a2"
-dependencies = [
- "either",
- "futures",
- "pin-project",
- "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "ufotofu"
@@ -1189,19 +1352,19 @@ dependencies = [
  "arbitrary",
  "either",
  "pollster",
- "ufotofu 0.7.0",
+ "ufotofu",
  "wb_async_utils",
 ]
 
 [[package]]
 name = "ufotofu_codec_endian"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb93cb00d9ae0a3d7ba45f779de03faf8aab584c68b4d4266b3377fa90d027d"
+checksum = "576a1a4636fda625a410d888802911b26a931a97f5cb9673584128b9278bdad2"
 dependencies = [
  "arbitrary",
  "either",
- "ufotofu 0.6.7",
+ "ufotofu",
  "ufotofu_codec",
 ]
 
@@ -1222,6 +1385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,9 +1398,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1250,7 +1419,7 @@ checksum = "29d07b9a0090d19edefbe07a6f7b19e7ba3f883dc2ef69f31e4edcb366b36ad8"
 dependencies = [
  "either",
  "fairly_unsafe_cell",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1266,7 +1435,7 @@ dependencies = [
  "lcmux",
  "multimap",
  "smol",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wb_async_utils",
@@ -1287,7 +1456,7 @@ dependencies = [
  "either",
  "slab",
  "smol",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "ufotofu_codec_endian",
  "wb_async_utils",
@@ -1313,7 +1482,7 @@ dependencies = [
  "sled",
  "syncify",
  "tempdir",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "ufotofu_codec_endian",
  "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1334,7 +1503,7 @@ dependencies = [
  "arbitrary",
  "compact_u64",
  "pollster",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "willow-data-model",
  "willow-encoding",
@@ -1346,7 +1515,7 @@ version = "0.1.0"
 dependencies = [
  "either",
  "sled",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "ufotofu_codec_endian",
  "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1362,7 +1531,7 @@ dependencies = [
  "either",
  "futures",
  "smol",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "ufotofu_queues 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wb_async_utils",
@@ -1379,7 +1548,7 @@ dependencies = [
  "meadowcap",
  "rand 0.8.5",
  "signature",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "willow-data-model",
  "willow-encoding",
@@ -1392,7 +1561,7 @@ dependencies = [
  "arbitrary",
  "meadowcap",
  "pollster",
- "ufotofu 0.7.0",
+ "ufotofu",
  "ufotofu_codec",
  "willow-data-model",
  "willow_25",
@@ -1421,20 +1590,123 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
+name = "windows"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1446,52 +1718,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+name = "windows-threading"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -1499,23 +1780,23 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,15 @@ members = [
     "willow_25",
     "transport_encryption",
     "pio",
-    "willow_test_vectors"
+    "willow_test_vectors",
 ]
 
 resolver = "2"
 
 [patch.crates-io]
-ufotofu_codec = { path="../ufotofu/ufotofu_codec", features = ["std", "dev"] }
-ufotofu = { path="../ufotofu/ufotofu", features = ["std", "dev"] }
+ufotofu_codec = { path = "../ufotofu/ufotofu_codec", features = ["std", "dev"] }
+ufotofu = { path = "../ufotofu/ufotofu", features = ["std", "dev"] }
+compact_u64 = { path = "../compact_u64", features = ["std", "dev"] }
 
 [workspace.lints.clippy]
 type_complexity = "allow"

--- a/data-model/Cargo.toml
+++ b/data-model/Cargo.toml
@@ -10,19 +10,17 @@ default = []
 dev = ["dep:arbitrary"]
 
 [dependencies]
+ufotofu = { version = "0.7.0", features = ["std"] }
+ufotofu_codec = "0.1.3"
+ufotofu_codec_endian = "0.1.0"
+wb_async_utils = { version = "0.2.0" }
 either = "1.10.0"
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-ufotofu = { version = "0.6.0", features = ["std"] }
 bytes = "1.6.0"
 slab = "0.4.9"
-wb_async_utils = { version = "0.1.3" }
-ufotofu_codec_endian = "0.1.0"
 
 [dependencies.willow-encoding]
 path = "../encoding"
-version = "0.1.0"
-
-[dependencies.ufotofu_codec]
 version = "0.1.0"
 
 [dependencies.compact_u64]

--- a/data-model/Cargo.toml
+++ b/data-model/Cargo.toml
@@ -12,8 +12,9 @@ dev = ["dep:arbitrary"]
 [dependencies]
 ufotofu = { version = "0.7.0", features = ["std"] }
 ufotofu_codec = "0.1.3"
-ufotofu_codec_endian = "0.1.0"
+ufotofu_codec_endian = "0.2.0"
 wb_async_utils = { version = "0.2.0" }
+compact_u64 = "0.2.0"
 either = "1.10.0"
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
 bytes = "1.6.0"
@@ -21,9 +22,6 @@ slab = "0.4.9"
 
 [dependencies.willow-encoding]
 path = "../encoding"
-version = "0.1.0"
-
-[dependencies.compact_u64]
 version = "0.1.0"
 
 [dev-dependencies]

--- a/data-model/src/parameters.rs
+++ b/data-model/src/parameters.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 /// When an implementing type implements [`PartialOrd`], then `Self::default()` must return a least element with respect to the ordering.
 ///
 /// [Definition](https://willowprotocol.org/specs/data-model/index.html#NamespaceId).
-pub trait NamespaceId: Eq + Default + Clone + Debug {}
+pub trait NamespaceId: Eq + Default + Clone + Debug + 'static {}
 
 /// A type for identifying [subspaces](https://willowprotocol.org/specs/data-model/index.html#subspace).
 ///
@@ -15,7 +15,7 @@ pub trait NamespaceId: Eq + Default + Clone + Debug {}
 /// ## Implementation notes
 ///
 /// The [`Default`] implementation **must** return the least element in the total order of [`SubspaceId`].
-pub trait SubspaceId: Ord + Default + Clone + Debug {
+pub trait SubspaceId: Ord + Default + Clone + Debug + 'static {
     /// Returns the next possible value in the set of all [`SubspaceId`], i.e. the (unique) least value that is strictly greater than `self`. Only if there is no greater value at all may this method return `None`.
     fn successor(&self) -> Option<Self>;
 }
@@ -29,7 +29,7 @@ pub trait SubspaceId: Ord + Default + Clone + Debug {
 /// ## Implementation notes
 ///
 /// The [`Default`] implementation **must** return the least element in the total order of [`PayloadDigest`].
-pub trait PayloadDigest: Ord + Default + Clone + Debug {
+pub trait PayloadDigest: Ord + Default + Clone + Debug + 'static {
     /// The state for hashing slices of bytes.
     type Hasher;
 

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -5,15 +5,5 @@ edition = "2021"
 description = "Utilities for implementing encoders and decoders of Willow types and messages."
 license = "MIT OR Apache-2.0"
 
-[dependencies]
-ufotofu = { version = "0.6.0", features = [
-    "std",
-    "dev",
-] } # Cargo does not support enabling a feature (`"dev"`) only during testing =(
-either = "1.10.0"
-
-[dev-dependencies]
-pollster = "0.4.0"
-
 [lints]
 workspace = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,20 +11,20 @@ cargo-fuzz = true
 workspace = true
 
 [dependencies]
-ufotofu = { version = "0.6.5", features = ["std", "dev"] }
+ufotofu = { version = "0.7.0", features = ["std", "dev"] }
 # ufotofu = { path = "../../ufotofu/ufotofu", features = ["std", "dev"] }
+ufotofu_codec = { version = "0.1.3", features = ["std", "dev"] }
+ufotofu_codec_endian = { version = "0.1.0", features = ["std"] }
 ufotofu_queues = { version = "0.6.0", features = ["std"] }
+wb_async_utils = { version = "0.2.0", features = ["ufotofu_utils"] }
 pollster = "0.4.0"
 arbitrary = { version = "1.0.2", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 signature = "2.2.0"
 syncify = "0.1.0"
 willow-encoding = { path = "../encoding" }
-ufotofu_codec = { version = "0.1.0", features = ["std", "dev"] }
-ufotofu_codec_endian = { version = "0.1.0", features = ["std"] }
 compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
 either = "1.10.0"
-wb_async_utils = { version = "0.1.3", features = ["ufotofu_utils"] }
 futures = { version = "0.3.31" }
 willow-store-simple-sled = { path = "../store_simple_sled" }
 sled = "0.34.7"
@@ -32,7 +32,7 @@ tempdir = "0.3.7"
 willow-transport-encryption = { path = "../transport_encryption" }
 willow_25 = { path = "../willow_25", features = ["dev"] }
 wgps = { path = "../wgps", features = ["dev"] }
-willow-pio = {version = "0.1.0", path = "../pio", features = ["dev"] }
+willow-pio = { version = "0.1.0", path = "../pio", features = ["dev"] }
 
 [dependencies.willow-data-model]
 path = "../data-model"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,16 +14,16 @@ workspace = true
 ufotofu = { version = "0.7.0", features = ["std", "dev"] }
 # ufotofu = { path = "../../ufotofu/ufotofu", features = ["std", "dev"] }
 ufotofu_codec = { version = "0.1.3", features = ["std", "dev"] }
-ufotofu_codec_endian = { version = "0.1.0", features = ["std"] }
+ufotofu_codec_endian = { version = "0.2.0", features = ["std"] }
 ufotofu_queues = { version = "0.6.0", features = ["std"] }
 wb_async_utils = { version = "0.2.0", features = ["ufotofu_utils"] }
+compact_u64 = { version = "0.2.0", features = ["std", "dev"] }
 pollster = "0.4.0"
 arbitrary = { version = "1.0.2", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 signature = "2.2.0"
 syncify = "0.1.0"
 willow-encoding = { path = "../encoding" }
-compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
 either = "1.10.0"
 futures = { version = "0.3.31" }
 willow-store-simple-sled = { path = "../store_simple_sled" }

--- a/lcmux/Cargo.toml
+++ b/lcmux/Cargo.toml
@@ -4,15 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-either = "1.10.0"
-wb_async_utils = { version = "0.1.3", features = [
-    "ufotofu_utils",
-] }
-ufotofu = { version = "0.6.0", features = ["std"] }
-ufotofu_codec = { version = "0.1.0" }
+ufotofu = { version = "0.7.0", features = ["std"] }
+ufotofu_codec = { version = "0.1.3" }
 ufotofu_codec_endian = { version = "0.1.0" }
-compact_u64 = { version = "0.1.0" }
 ufotofu_queues = { version = "0.6.0", features = ["std"] }
+wb_async_utils = { version = "0.2.0", features = ["ufotofu_utils"] }
+either = "1.10.0"
+compact_u64 = { version = "0.1.0" }
 async_cell = "0.2.2"
 futures = { version = "0.3.31" }
 willow-encoding = { path = "../encoding", version = "0.1.0" }

--- a/lcmux/Cargo.toml
+++ b/lcmux/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 [dependencies]
 ufotofu = { version = "0.7.0", features = ["std"] }
 ufotofu_codec = { version = "0.1.3" }
-ufotofu_codec_endian = { version = "0.1.0" }
+ufotofu_codec_endian = { version = "0.2.0" }
 ufotofu_queues = { version = "0.6.0", features = ["std"] }
 wb_async_utils = { version = "0.2.0", features = ["ufotofu_utils"] }
+compact_u64 = { version = "0.2.0" }
 either = "1.10.0"
-compact_u64 = { version = "0.1.0" }
 async_cell = "0.2.2"
 futures = { version = "0.3.31" }
 willow-encoding = { path = "../encoding", version = "0.1.0" }

--- a/lcmux/src/client_logic.rs
+++ b/lcmux/src/client_logic.rs
@@ -12,7 +12,7 @@
 //!
 //! The implementation does not concern itself with incoming `AnnounceDropping` messages, nor with sending `Apologise` messages, because neither occurs (in communication with a correct peer) since it never sends optimistically.
 
-use std::{num::NonZeroU64, ops::Deref};
+use std::{num::NonZeroU64, ops::Deref, rc::Rc};
 
 use ufotofu::BulkConsumer;
 
@@ -31,7 +31,7 @@ use crate::{
 
 /// The opaque state by which the separate components of a [`ClientLogic`] struct can communicate.
 #[derive(Debug)]
-pub(crate) struct State {
+struct State {
     // Absolutions that should be granted to the server. Closed with `()` when we have no guarantees available and know that the server will never grant us any new ones either.
     absolution: shelf::State<NonZeroU64, ()>,
     // Guarantees that the server has granted us, with the option to subscribe to some particular amount becoming available. The `Final` value `()` is emitted when we know that the currently desired amount will never become available (because of a bound on the incoming guarantees).
@@ -41,7 +41,7 @@ pub(crate) struct State {
 }
 
 impl State {
-    pub fn new(channel_id: u64) -> Self {
+    fn new(channel_id: u64) -> Self {
         Self {
             absolution: shelf::State::new(),
             guarantees: GuaranteeCell::new(),
@@ -51,23 +51,22 @@ impl State {
 }
 
 /// Everything you need to correctly manage an LCMUX client.
-pub(crate) struct ClientLogic<R> {
+pub(crate) struct ClientLogic {
     /// Inform the client logic about incoming control messages about this logical channel.
-    pub receiver: MessageReceiver<R>,
+    pub receiver: MessageReceiver,
     /// Receive information about when to grant absolution on this logical channel. Whenever a value is read from this shelf, the client logic assumes that the absolution will be granted.
-    pub grant_absolution: GrantAbsolution<R>,
+    pub grant_absolution: GrantAbsolution,
     /// Allows sending messages to this channel, also allows sending `LimitSending` frames.
-    pub sender: SendToChannel<R>,
+    pub sender: SendToChannel,
 }
 
-pub(crate) type GrantAbsolution<R> = shelf::Receiver<ProjectAbsolutionShelf<R>, NonZeroU64, ()>;
+pub(crate) type GrantAbsolution = shelf::Receiver<ProjectAbsolutionShelf, NonZeroU64, ()>;
 
-impl<R> ClientLogic<R>
-where
-    R: Deref<Target = State> + Clone,
-{
+impl ClientLogic {
     /// The effective entrypoint to this module. Given a reference to an opaque state handle, this returns the client session state for single logical channel.
-    pub fn new(state: R) -> Self {
+    pub fn new(channel_id: u64) -> Self {
+        let state = Rc::new(State::new(channel_id));
+
         let (shelf_sender, shelf_receiver) = new_shelf(ProjectAbsolutionShelf { r: state.clone() });
 
         ClientLogic {
@@ -82,15 +81,12 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) struct MessageReceiver<R> {
-    state: R,
-    absolution_shelf_sender: shelf::Sender<ProjectAbsolutionShelf<R>, NonZeroU64, ()>,
+pub(crate) struct MessageReceiver {
+    state: Rc<State>,
+    absolution_shelf_sender: shelf::Sender<ProjectAbsolutionShelf, NonZeroU64, ()>,
 }
 
-impl<R> MessageReceiver<R>
-where
-    R: Deref<Target = State>,
-{
+impl MessageReceiver {
     /// Updates the client state with more guarantees. To be called whenever receiving a [IssueGuarantee](https://willowprotocol.org/specs/resource-control/index.html#ResourceControlGuarantee) message.
     ///
     /// Returns an `Err(())` when the available guarantees would exceed the maximum of `2^64 - 1`, or when the guarantees would disrespect a prior bound on guarantees. If either happens, the logical channel should be considered completely unuseable (and usually, the whole connection should be dropped, since we are talking to a buggy or malicious peer).
@@ -129,14 +125,11 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) struct SendToChannel<R> {
-    pub(crate) state: R,
+pub(crate) struct SendToChannel {
+    state: Rc<State>,
 }
 
-impl<R> SendToChannel<R>
-where
-    R: Deref<Target = State>,
-{
+impl SendToChannel {
     /// Pause until the desired amount of guarantees is available, then reduce the internal state by that amount. In other words, once the guarantees are available, they *must* be used up by sending messages of that side.
     /// Yields an error if the guarantees are known to never become available (because the server communicated a bound on how many guarantees it will still send at most).
     async fn wait_for_guarantees(&mut self, amount: u64) -> Result<(), ()> {
@@ -148,14 +141,15 @@ where
     }
 
     /// Send a message to a logical channel. Waits for the necessary guarantees to become available before requesting exclusive access to the consumer for writing the encoded message (and its header).
-    pub async fn send_to_channel<CR, C, M>(
+    pub async fn send_to_channel<CR, C, CError, M>(
         &mut self,
-        consumer: &SharedConsumer<CR, C>,
+        consumer: &SharedConsumer<CR, C, CError>,
         message: &M,
     ) -> Result<(), LogicalChannelClientError<C::Error>>
     where
-        C: BulkConsumer<Item = u8, Final: Clone, Error: Clone>,
-        CR: Deref<Target = shared_consumer::State<C>> + Clone,
+        C: BulkConsumer<Item = u8, Final: Clone, Error = CError>,
+        CError: Clone,
+        CR: Deref<Target = shared_consumer::State<C, CError>> + Clone,
         M: EncodableKnownSize,
     {
         let size = message.len_of_encoding() as u64;
@@ -178,15 +172,16 @@ where
     }
 
     /// Send a message to a logical channel, using a relative encoding. Waits for the necessary guarantees to become available before requesting exclusive access to the consumer for writing the encoded message (and its header).
-    pub async fn send_to_channel_relative<CR, C, M, RelativeTo>(
+    pub async fn send_to_channel_relative<CR, C, CError, M, RelativeTo>(
         &mut self,
-        consumer: &SharedConsumer<CR, C>,
+        consumer: &SharedConsumer<CR, C, CError>,
         message: &M,
         relative_to: &RelativeTo,
     ) -> Result<(), LogicalChannelClientError<C::Error>>
     where
-        C: BulkConsumer<Item = u8, Final: Clone, Error: Clone>,
-        CR: Deref<Target = shared_consumer::State<C>> + Clone,
+        C: BulkConsumer<Item = u8, Final: Clone, Error = CError>,
+        CError: Clone,
+        CR: Deref<Target = shared_consumer::State<C, CError>> + Clone,
         M: RelativeEncodableKnownSize<RelativeTo>,
     {
         let size = message.relative_len_of_encoding(relative_to) as u64;
@@ -211,14 +206,15 @@ where
     /// Send a `LimitSending` frame to the server.
     ///
     /// This method does not check that you send valid limits or that you respect them on the future.
-    pub async fn limit_sending<CR, C>(
+    pub async fn limit_sending<CR, C, CError>(
         &mut self,
-        consumer: &SharedConsumer<CR, C>,
+        consumer: &SharedConsumer<CR, C, CError>,
         bound: u64,
     ) -> Result<(), C::Error>
     where
-        C: BulkConsumer<Item = u8, Final: Clone, Error: Clone>,
-        CR: Deref<Target = shared_consumer::State<C>> + Clone,
+        C: BulkConsumer<Item = u8, Final: Clone, Error = CError>,
+        CError: Clone,
+        CR: Deref<Target = shared_consumer::State<C, CError>> + Clone,
     {
         let frame = LimitSending {
             channel: self.state.deref().channel_id,
@@ -248,14 +244,11 @@ impl<E> From<E> for LogicalChannelClientError<E> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ProjectAbsolutionShelf<R> {
-    r: R,
+pub(crate) struct ProjectAbsolutionShelf {
+    r: Rc<State>,
 }
 
-impl<R> Deref for ProjectAbsolutionShelf<R>
-where
-    R: Deref<Target = State>,
-{
+impl Deref for ProjectAbsolutionShelf {
     type Target = shelf::State<NonZeroU64, ()>;
 
     fn deref(&self) -> &Self::Target {
@@ -275,8 +268,7 @@ mod tests {
 
     #[test]
     fn test_bound() {
-        let state = State::new(17);
-        let mut client_logic = ClientLogic::new(&state);
+        let mut client_logic = ClientLogic::new(17);
 
         assert_eq!(Ok(()), client_logic.receiver.receive_guarantees(12));
         assert_eq!(Ok(()), client_logic.receiver.receive_limit_receiving(8));
@@ -286,8 +278,7 @@ mod tests {
 
     #[test]
     fn test_plead() {
-        let state = State::new(17);
-        let mut client_logic = ClientLogic::new(&state);
+        let mut client_logic = ClientLogic::new(17);
 
         block_on(async {
             assert_eq!(Ok(()), client_logic.receiver.receive_guarantees(12));
@@ -334,8 +325,7 @@ mod tests {
 
     #[test]
     fn test_sending() {
-        let state = State::new(17);
-        let mut client_logic = ClientLogic::new(&state);
+        let mut client_logic = ClientLogic::new(17);
 
         let inner_consumer = IntoVec::new();
         let shared_consumer_state = shared_consumer::State::new(inner_consumer);

--- a/lcmux/src/session.rs
+++ b/lcmux/src/session.rs
@@ -16,6 +16,7 @@ use std::{
     mem::MaybeUninit,
     num::NonZeroU64,
     ops::Deref,
+    rc::Rc,
 };
 
 use either::Either::{self, *};
@@ -59,50 +60,26 @@ pub struct InitOptions {
 }
 
 /// The state for an Lcmux session for channels `0` to `NUM_CHANNELS - 1`.
-///
-/// This struct is opaque, but we expose it to allow for control over where it is allocated.
 #[derive(Debug)]
-pub struct State<const NUM_CHANNELS: usize, P, PR, C, CR>
-where
-    P: Producer,
-    C: Consumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
-{
-    channel_states: [(client_logic::State, server_logic::State<Fixed<u8>>); NUM_CHANNELS],
-    p: SharedProducer<PR, P>,
-    c: SharedConsumer<CR, C>,
+struct State<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr> {
+    p: SharedProducer<Rc<shared_producer::State<P, PFinal, PErr>>, P, PFinal, PErr>,
+    c: SharedConsumer<Rc<shared_consumer::State<C, CErr>>, C, CErr>,
     number_of_nonempty_urgent_channels: Cell<usize>,
     no_urgency_notifier: TakeCell<()>, // empty while number_of_nonempty_urgent_channels is nonzero
 }
 
-impl<const NUM_CHANNELS: usize, P, PR, C, CR> State<NUM_CHANNELS, P, PR, C, CR>
-where
-    P: Producer,
-    C: Consumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+impl<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr>
+    State<NUM_CHANNELS, P, PFinal, PErr, C, CErr>
 {
     /// Create a new opaque state for an LCMUX session.
     ///
     /// The `buffer_capacity` specifies how many bytes each logical channel can buffer at most.
     /// The `watermark` specifies how many guarantees must become grantable at least before they are actually granted.
-    pub fn new(
-        p: SharedProducer<PR, P>,
-        c: SharedConsumer<CR, C>,
-        options: [&ChannelOptions; NUM_CHANNELS],
+    fn new(
+        p: SharedProducer<Rc<shared_producer::State<P, PFinal, PErr>>, P, PFinal, PErr>,
+        c: SharedConsumer<Rc<shared_consumer::State<C, CErr>>, C, CErr>,
     ) -> Self {
         Self {
-            channel_states: core::array::from_fn(|i| {
-                (
-                    client_logic::State::new(i as u64),
-                    server_logic::State::new(
-                        Fixed::new(options[i].buffer_capacity),
-                        options[i].buffer_capacity,
-                        options[i].watermark,
-                    ),
-                )
-            }),
             p,
             c,
             number_of_nonempty_urgent_channels: Cell::new(0),
@@ -133,60 +110,68 @@ where
 #[derive(Debug)]
 pub struct Session<
     const NUM_CHANNELS: usize,
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    C: Consumer,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+    P,
+    PFinal,
+    PErr,
+    C,
+    CErr,
     GlobalMessage,
     GlobalMessageDecodeErrorReason,
 > {
     /// A struct with an async function whose Future must be polled to completion to run the LCMUX session. Yields `Ok(())` if every logical channel got closed by both peers, yields an `Err` if *any* channel encounters any error.
-    pub bookkeeping: Bookkeeping<NUM_CHANNELS, R, P, PR, C, CR>,
+    pub bookkeeping: Bookkeeping<NUM_CHANNELS, P, PFinal, PErr, C, CErr>,
     /// A struct for sending global messages to the other peer.
-    pub global_sender: GlobalMessageSender<NUM_CHANNELS, R>,
+    pub global_sender: GlobalMessageSender<NUM_CHANNELS, P, PFinal, PErr, C, CErr>,
     /// A struct for receiving global messages from the other peer.
     pub global_receiver: GlobalMessageReceiver<
         NUM_CHANNELS,
-        R,
         P,
-        PR,
+        PFinal,
+        PErr,
         C,
-        CR,
+        CErr,
         GlobalMessage,
         GlobalMessageDecodeErrorReason,
     >,
     /// A struct for sending global messages to the other peer.
     /// For each logical channel, a way to send data to that channel via `SendToChannel` frames.
-    pub channel_senders: [ChannelSender<NUM_CHANNELS, R, P, PR, C, CR>; NUM_CHANNELS],
+    pub channel_senders: [ChannelSender<NUM_CHANNELS, P, PFinal, PErr, C, CErr>; NUM_CHANNELS],
     /// For each logical channel, a producer of the bytes that were sent to that channel via `SendToChannel` frames.
-    pub channel_receivers: [ChannelReceiver<NUM_CHANNELS, R, P, PR, C, CR>; NUM_CHANNELS],
+    pub channel_receivers: [ChannelReceiver<NUM_CHANNELS, P, PFinal, PErr, C, CErr>; NUM_CHANNELS],
 }
 
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR, GlobalMessage, GlobalMessageDecodeErrorReason>
-    Session<NUM_CHANNELS, R, P, PR, C, CR, GlobalMessage, GlobalMessageDecodeErrorReason>
+impl<
+        const NUM_CHANNELS: usize,
+        P,
+        PFinal,
+        PErr,
+        C,
+        CErr,
+        GlobalMessage,
+        GlobalMessageDecodeErrorReason,
+    > Session<NUM_CHANNELS, P, PFinal, PErr, C, CErr, GlobalMessage, GlobalMessageDecodeErrorReason>
 where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>> + Clone,
     P: Producer,
-    C: BulkConsumer<Item = u8, Final: Clone, Error: Clone>,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+    C: BulkConsumer<Item = u8, Final: Clone, Error = CErr>,
+    CErr: Clone,
 {
     /// Creates a new LCMUX session.
-    pub fn new(state_ref: R, which_channels_are_urgent: [bool; NUM_CHANNELS]) -> Self {
-        let client_logics: [_; NUM_CHANNELS] = core::array::from_fn(|channel_id| {
-            ClientLogic::new(ProjectIthClientState {
-                r: state_ref.clone(),
-                i: channel_id,
-                phantom: PhantomData,
-            })
-        });
+    pub fn new(
+        p: SharedProducer<Rc<shared_producer::State<P, PFinal, PErr>>, P, PFinal, PErr>,
+        c: SharedConsumer<Rc<shared_consumer::State<C, CErr>>, C, CErr>,
+        options: [&ChannelOptions; NUM_CHANNELS],
+        which_channels_are_urgent: [bool; NUM_CHANNELS],
+    ) -> Self {
+        let state = Rc::new(State::new(p, c));
+
+        let client_logics: [_; NUM_CHANNELS] =
+            core::array::from_fn(|channel_id| ClientLogic::new(channel_id as u64));
         let server_logics: [_; NUM_CHANNELS] = core::array::from_fn(|channel_id| {
-            ServerLogic::new(ProjectIthServerState {
-                r: state_ref.clone(),
-                i: channel_id,
-                phantom: PhantomData,
-            })
+            ServerLogic::new(
+                Fixed::new(options[channel_id].buffer_capacity),
+                options[channel_id].buffer_capacity,
+                options[channel_id].watermark,
+            )
         });
 
         // Now we do a silly dance to create a bunch of arrays of the components.
@@ -236,26 +221,29 @@ where
 
         Self {
             bookkeeping: Bookkeeping {
-                state: state_ref.clone(),
+                state: state.clone(),
                 client_grant_absolutions: Some(client_grant_absolutions),
                 server_guarantees_to_gives: Some(server_guarantees_to_gives),
                 server_start_droppings: Some(server_start_droppings),
             },
             global_sender: GlobalMessageSender {
-                state: state_ref.clone(),
+                state: state.clone(),
             },
             global_receiver: GlobalMessageReceiver {
-                state: state_ref.clone(),
+                state: state.clone(),
                 client_receivers,
                 server_receivers,
                 urgent_channels: which_channels_are_urgent,
                 phantom: PhantomData,
             },
-            channel_senders: client_senders.map(|send_to_channel| ChannelSender(send_to_channel)),
+            channel_senders: client_senders.map(|send_to_channel| ChannelSender {
+                state: state.clone(),
+                send_to_channel,
+            }),
             channel_receivers: server_received_datas.map(|receive_data| {
                 let ret = ChannelReceiver {
                     received_data: receive_data,
-                    session_state: state_ref.clone(),
+                    session_state: state.clone(),
                     is_urgent: which_channels_are_urgent[i],
                 };
                 i += 1;
@@ -283,17 +271,17 @@ where
 }
 
 #[derive(Debug)]
-pub struct ChannelSender<const NUM_CHANNELS: usize, R, P, PR, C, CR>(
-    client_logic::SendToChannel<ProjectIthClientState<NUM_CHANNELS, R, P, PR, C, CR>>,
-);
+pub struct ChannelSender<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr> {
+    send_to_channel: client_logic::SendToChannel,
+    state: Rc<State<NUM_CHANNELS, P, PFinal, PErr, C, CErr>>,
+}
 
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> ChannelSender<NUM_CHANNELS, R, P, PR, C, CR>
+impl<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr>
+    ChannelSender<NUM_CHANNELS, P, PFinal, PErr, C, CErr>
 where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    C: BulkConsumer<Item = u8, Final: Clone, Error: Clone>,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+    // P: Producer,
+    C: BulkConsumer<Item = u8, Final: Clone, Error = CErr>,
+    CErr: Clone,
 {
     /// Send a message to a logical channel. Waits for the necessary guarantees to become available before requesting exclusive access to the consumer for writing the encoded message (and its header).
     pub async fn send_to_channel<M>(
@@ -303,8 +291,10 @@ where
     where
         M: EncodableKnownSize,
     {
-        let consumer = self.0.state.r.c.clone();
-        self.0.send_to_channel(&consumer, message).await
+        let consumer = self.state.c.clone();
+        self.send_to_channel
+            .send_to_channel(&consumer, message)
+            .await
     }
 
     /// Send a message to a logical channel, using a relative encoding. Waits for the necessary guarantees to become available before requesting exclusive access to the consumer for writing the encoded message (and its header).
@@ -316,8 +306,8 @@ where
     where
         M: RelativeEncodableKnownSize<RelativeTo>,
     {
-        let consumer = self.0.state.r.c.clone();
-        self.0
+        let consumer = self.state.c.clone();
+        self.send_to_channel
             .send_to_channel_relative(&consumer, message, relative_to)
             .await
     }
@@ -326,8 +316,8 @@ where
     ///
     /// This method does not check that you send valid limits or that you respect them on the future.
     pub async fn limit_sending(&mut self, bound: u64) -> Result<(), C::Error> {
-        let consumer = self.0.state.r.c.clone();
-        self.0.limit_sending(&consumer, bound).await
+        let consumer = self.state.c.clone();
+        self.send_to_channel.limit_sending(&consumer, bound).await
     }
 
     /// Same as `self.limit_sending(0)`.
@@ -337,30 +327,14 @@ where
 }
 
 #[derive(Debug)]
-pub struct ChannelReceiver<
-    const NUM_CHANNELS: usize,
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    C: Consumer,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
-> {
-    received_data:
-        server_logic::ReceivedData<ProjectIthServerState<NUM_CHANNELS, R, P, PR, C, CR>, Fixed<u8>>,
-    session_state: R,
+pub struct ChannelReceiver<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr> {
+    received_data: server_logic::ReceivedData<Fixed<u8>>,
+    session_state: Rc<State<NUM_CHANNELS, P, PFinal, PErr, C, CErr>>,
     is_urgent: bool,
 }
 
-// (server_logic::ReceivedData<ProjectIthServerState<NUM_CHANNELS, R, P, PR, C, CR>, Fixed<u8>>, bool);
-
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> Producer
-    for ChannelReceiver<NUM_CHANNELS, R, P, PR, C, CR>
-where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    C: Consumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+impl<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr> Producer
+    for ChannelReceiver<NUM_CHANNELS, P, PFinal, PErr, C, CErr>
 {
     type Item = u8;
 
@@ -389,28 +363,16 @@ where
     }
 }
 
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> BufferedProducer
-    for ChannelReceiver<NUM_CHANNELS, R, P, PR, C, CR>
-where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    C: Consumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+impl<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr> BufferedProducer
+    for ChannelReceiver<NUM_CHANNELS, P, PFinal, PErr, C, CErr>
 {
     async fn slurp(&mut self) -> Result<(), Self::Error> {
         self.received_data.slurp().await
     }
 }
 
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> BulkProducer
-    for ChannelReceiver<NUM_CHANNELS, R, P, PR, C, CR>
-where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    C: Consumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+impl<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr> BulkProducer
+    for ChannelReceiver<NUM_CHANNELS, P, PFinal, PErr, C, CErr>
 {
     async fn expose_items<'a>(
         &'a mut self,
@@ -440,33 +402,19 @@ where
 
 /// Call and poll to completion the `keep_the_books` method on this struct to run an LCMUX session.
 #[derive(Debug)]
-pub struct Bookkeeping<const NUM_CHANNELS: usize, R, P, PR, C, CR> {
-    state: R,
-    client_grant_absolutions: Option<
-        [client_logic::GrantAbsolution<ProjectIthClientState<NUM_CHANNELS, R, P, PR, C, CR>>;
-            NUM_CHANNELS],
-    >,
-    server_guarantees_to_gives: Option<
-        [server_logic::GuaranteesToGive<
-            ProjectIthServerState<NUM_CHANNELS, R, P, PR, C, CR>,
-            Fixed<u8>,
-        >; NUM_CHANNELS],
-    >,
-    server_start_droppings: Option<
-        [server_logic::StartDropping<
-            ProjectIthServerState<NUM_CHANNELS, R, P, PR, C, CR>,
-            Fixed<u8>,
-        >; NUM_CHANNELS],
-    >,
+pub struct Bookkeeping<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr> {
+    state: Rc<State<NUM_CHANNELS, P, PFinal, PErr, C, CErr>>,
+    client_grant_absolutions: Option<[client_logic::GrantAbsolution; NUM_CHANNELS]>,
+    server_guarantees_to_gives: Option<[server_logic::GuaranteesToGive<Fixed<u8>>; NUM_CHANNELS]>,
+    server_start_droppings: Option<[server_logic::StartDropping<Fixed<u8>>; NUM_CHANNELS]>,
 }
 
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> Bookkeeping<NUM_CHANNELS, R, P, PR, C, CR>
+impl<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr>
+    Bookkeeping<NUM_CHANNELS, P, PFinal, PErr, C, CErr>
 where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    C: Consumer<Item = u8, Final = (), Error: Clone> + BulkConsumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+    P: Producer<Final = PFinal, Error = PErr>,
+    C: Consumer<Item = u8, Final = (), Error = CErr> + BulkConsumer,
+    CErr: Clone,
 {
     /// You must call this function once and poll it to completion to run the session. Otherwise, GrantAbsolution, GiveGuarantees, and StartDropping frames will not be sent.
     ///
@@ -585,17 +533,15 @@ where
 
 /// Send global messages to the other peer via this struct.
 #[derive(Debug)]
-pub struct GlobalMessageSender<const NUM_CHANNELS: usize, R> {
-    state: R,
+pub struct GlobalMessageSender<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr> {
+    state: Rc<State<NUM_CHANNELS, P, PFinal, PErr, C, CErr>>,
 }
 
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> GlobalMessageSender<NUM_CHANNELS, R>
+impl<const NUM_CHANNELS: usize, P, PFinal, PErr, C, CErr>
+    GlobalMessageSender<NUM_CHANNELS, P, PFinal, PErr, C, CErr>
 where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    C: Consumer<Item = u8, Final = (), Error: Clone> + BulkConsumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+    C: Consumer<Item = u8, Final = (), Error = CErr> + BulkConsumer,
+    CErr: Clone,
 {
     pub async fn send_global_message<CMessage: EncodableKnownSize>(
         &mut self,
@@ -616,44 +562,45 @@ where
 #[derive(Debug)]
 pub struct GlobalMessageReceiver<
     const NUM_CHANNELS: usize,
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    C: Consumer,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+    P,
+    PFinal,
+    PErr,
+    C,
+    CErr,
     GlobalMessage,
     GlobalMessageDecodeErrorReason,
 > {
-    state: R,
-    client_receivers: [client_logic::MessageReceiver<
-        ProjectIthClientState<NUM_CHANNELS, R, P, PR, C, CR>,
-    >; NUM_CHANNELS],
-    server_receivers: [server_logic::MessageReceiver<
-        ProjectIthServerState<NUM_CHANNELS, R, P, PR, C, CR>,
-        Fixed<u8>,
-    >; NUM_CHANNELS],
+    state: Rc<State<NUM_CHANNELS, P, PFinal, PErr, C, CErr>>,
+    client_receivers: [client_logic::MessageReceiver; NUM_CHANNELS],
+    server_receivers: [server_logic::MessageReceiver<Fixed<u8>>; NUM_CHANNELS],
     urgent_channels: [bool; NUM_CHANNELS],
     phantom: PhantomData<(GlobalMessage, GlobalMessageDecodeErrorReason)>,
 }
 
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR, GlobalMessage, GlobalMessageDecodeErrorReason>
-    Producer
+impl<
+        const NUM_CHANNELS: usize,
+        P,
+        PFinal,
+        PErr,
+        C,
+        CErr,
+        GlobalMessage,
+        GlobalMessageDecodeErrorReason,
+    > Producer
     for GlobalMessageReceiver<
         NUM_CHANNELS,
-        R,
         P,
-        PR,
+        PFinal,
+        PErr,
         C,
-        CR,
+        CErr,
         GlobalMessage,
         GlobalMessageDecodeErrorReason,
     >
 where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: BulkProducer<Item = u8, Final: Clone, Error: Clone>,
-    C: Consumer<Item = u8, Final = (), Error: Clone> + BulkConsumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
+    P: BulkProducer<Item = u8, Final = PFinal, Error = PErr>,
+    PFinal: Clone,
+    PErr: Clone,
     GlobalMessage: Decodable<ErrorReason = GlobalMessageDecodeErrorReason>,
 {
     type Item = GlobalMessage;
@@ -874,80 +821,6 @@ where
             GlobalMessageError::DecodeGlobalMessage(_)
             | GlobalMessageError::UnsupportedChannel(_)
             | GlobalMessageError::Other => None,
-        }
-    }
-}
-
-#[derive(Debug)]
-struct ProjectIthClientState<const NUM_CHANNELS: usize, R, P, PR, C, CR> {
-    r: R,
-    i: usize,
-    phantom: PhantomData<(P, PR, C, CR)>,
-}
-
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> Deref
-    for ProjectIthClientState<NUM_CHANNELS, R, P, PR, C, CR>
-where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    C: Consumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
-{
-    type Target = client_logic::State;
-
-    fn deref(&self) -> &Self::Target {
-        &self.r.deref().channel_states[self.i].0
-    }
-}
-
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> Clone
-    for ProjectIthClientState<NUM_CHANNELS, R, P, PR, C, CR>
-where
-    R: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            r: self.r.clone(),
-            i: self.i,
-            phantom: self.phantom,
-        }
-    }
-}
-
-#[derive(Debug)]
-struct ProjectIthServerState<const NUM_CHANNELS: usize, R, P, PR, C, CR> {
-    r: R,
-    i: usize,
-    phantom: PhantomData<(P, PR, C, CR)>,
-}
-
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> Deref
-    for ProjectIthServerState<NUM_CHANNELS, R, P, PR, C, CR>
-where
-    R: Deref<Target = State<NUM_CHANNELS, P, PR, C, CR>>,
-    P: Producer,
-    C: Consumer,
-    PR: Deref<Target = shared_producer::State<P>> + Clone,
-    CR: Deref<Target = shared_consumer::State<C>> + Clone,
-{
-    type Target = server_logic::State<Fixed<u8>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.r.deref().channel_states[self.i].1
-    }
-}
-
-impl<const NUM_CHANNELS: usize, R, P, PR, C, CR> Clone
-    for ProjectIthServerState<NUM_CHANNELS, R, P, PR, C, CR>
-where
-    R: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            r: self.r.clone(),
-            i: self.i,
-            phantom: self.phantom,
         }
     }
 }

--- a/meadowcap/Cargo.toml
+++ b/meadowcap/Cargo.toml
@@ -12,12 +12,12 @@ dev = ["dep:arbitrary", "willow-data-model/dev", "willow-pio/dev"]
 [dependencies]
 ufotofu = { version = "0.7.0", features = ["std"] }
 ufotofu_codec = { version = "0.1.3", features = ["alloc"] }
+compact_u64 = { version = "0.2.0", features = ["std", "dev"] }
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
 either = "1.13.0"
 signature = "2.2.0"
 willow-encoding = { path = "../encoding", version = "0.1.0" }
 willow-data-model = { path = "../data-model", version = "0.2.0" }
-compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
 willow-pio = { version = "0.1.0", path = "../pio" }
 
 [lints]

--- a/meadowcap/Cargo.toml
+++ b/meadowcap/Cargo.toml
@@ -10,19 +10,15 @@ default = []
 dev = ["dep:arbitrary", "willow-data-model/dev", "willow-pio/dev"]
 
 [dependencies]
-signature = "2.2.0"
-ufotofu = { version = "0.6.0", features = ["std"] }
+ufotofu = { version = "0.7.0", features = ["std"] }
+ufotofu_codec = { version = "0.1.3", features = ["alloc"] }
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
 either = "1.13.0"
+signature = "2.2.0"
 willow-encoding = { path = "../encoding", version = "0.1.0" }
 willow-data-model = { path = "../data-model", version = "0.2.0" }
-compact_u64 = { version = "0.1.0", features = [ "std", "dev" ] }
-willow-pio = {version = "0.1.0", path = "../pio" }
-
-[dependencies.ufotofu_codec]
-version = "0.1.1"
-features = ["alloc"]
-
+compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
+willow-pio = { version = "0.1.0", path = "../pio" }
 
 [lints]
 workspace = true

--- a/pio/Cargo.toml
+++ b/pio/Cargo.toml
@@ -10,14 +10,14 @@ default = []
 dev = ["dep:arbitrary", "willow-data-model/dev"]
 
 [dependencies]
-ufotofu = { version = "0.6.0", features = [
+ufotofu = { version = "0.7.0", features = [
     "std",
     "dev",
 ] } # Cargo does not support enabling a feature (`"dev"`) only during testing =(
+ufotofu_codec = { version = "0.1.3" }
 willow-data-model = { path = "../data-model", version = "0.2.0" }
-compact_u64 = { version = "0.1.0", features = [ "std", "dev" ] }
+compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-ufotofu_codec = { version = "0.1.1" }
 willow-encoding = { path = "../encoding", version = "0.1.0" }
 
 [dev-dependencies]

--- a/pio/Cargo.toml
+++ b/pio/Cargo.toml
@@ -15,8 +15,8 @@ ufotofu = { version = "0.7.0", features = [
     "dev",
 ] } # Cargo does not support enabling a feature (`"dev"`) only during testing =(
 ufotofu_codec = { version = "0.1.3" }
+compact_u64 = { version = "0.2.0", features = ["std", "dev"] }
 willow-data-model = { path = "../data-model", version = "0.2.0" }
-compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
 willow-encoding = { path = "../encoding", version = "0.1.0" }
 

--- a/pio/src/area.rs
+++ b/pio/src/area.rs
@@ -147,8 +147,8 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, N: Clone, S: Clone>
 impl<'a, const MCL: usize, const MCC: usize, const MPL: usize, N, S> Arbitrary<'a>
     for PrivateInterest<MCL, MCC, MPL, N, S>
 where
-    N: NamespaceId + Arbitrary<'a>,
-    S: SubspaceId + Arbitrary<'a>,
+    N: Arbitrary<'a>,
+    S: Arbitrary<'a>,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let namespace_id: N = Arbitrary::arbitrary(u)?;
@@ -165,13 +165,7 @@ where
 
 #[derive(Debug)]
 /// The context necessary to privately encode Areas.
-pub struct PrivateAreaContext<
-    const MCL: usize,
-    const MCC: usize,
-    const MPL: usize,
-    N: NamespaceId,
-    S: SubspaceId,
-> {
+pub struct PrivateAreaContext<const MCL: usize, const MCC: usize, const MPL: usize, N, S> {
     /// The PrivateInterest to be kept private.
     private: PrivateInterest<MCL, MCC, MPL, N, S>,
 
@@ -182,7 +176,7 @@ pub struct PrivateAreaContext<
 #[derive(Debug)]
 pub struct AreaNotAlmostIncludedError;
 
-impl<const MCL: usize, const MCC: usize, const MPL: usize, N: NamespaceId, S: SubspaceId>
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S>
     PrivateAreaContext<MCL, MCC, MPL, N, S>
 {
     pub fn new(
@@ -206,11 +200,11 @@ impl<const MCL: usize, const MCC: usize, const MPL: usize, N: NamespaceId, S: Su
 }
 
 #[cfg(feature = "dev")]
-impl<'a, const MCL: usize, const MCC: usize, const MPL: usize, N: NamespaceId, S: SubspaceId>
-    Arbitrary<'a> for PrivateAreaContext<MCL, MCC, MPL, N, S>
+impl<'a, const MCL: usize, const MCC: usize, const MPL: usize, N, S> Arbitrary<'a>
+    for PrivateAreaContext<MCL, MCC, MPL, N, S>
 where
-    N: NamespaceId + Arbitrary<'a>,
-    S: SubspaceId + Arbitrary<'a>,
+    N: Arbitrary<'a>,
+    S: Arbitrary<'a>,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
@@ -220,7 +214,7 @@ where
     }
 }
 
-impl<const MCL: usize, const MCC: usize, const MPL: usize, N: NamespaceId, S: SubspaceId>
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S: PartialEq + Clone>
     RelativeEncodable<PrivateAreaContext<MCL, MCC, MPL, N, S>> for Area<MCL, MCC, MPL, S>
 where
     S: Encodable,
@@ -361,7 +355,7 @@ where
     }
 }
 
-impl<const MCL: usize, const MCC: usize, const MPL: usize, N: NamespaceId, S: SubspaceId>
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, S: Clone>
     RelativeDecodable<PrivateAreaContext<MCL, MCC, MPL, N, S>, Blame> for Area<MCL, MCC, MPL, S>
 where
     S: Decodable,

--- a/pio/src/personal_private_interest.rs
+++ b/pio/src/personal_private_interest.rs
@@ -8,20 +8,15 @@ pub struct PersonalPrivateInterest<
     const MCL: usize,
     const MCC: usize,
     const MPL: usize,
-    N: NamespaceId,
-    UserPublicKey: SubspaceId,
+    N,
+    UserPublicKey,
 > {
     pub private_interest: PrivateInterest<MCL, MCC, MPL, N, UserPublicKey>,
     pub user_key: UserPublicKey,
 }
 
-impl<
-        const MCL: usize,
-        const MCC: usize,
-        const MPL: usize,
-        N: NamespaceId,
-        UserPublicKey: SubspaceId,
-    > PersonalPrivateInterest<MCL, MCC, MPL, N, UserPublicKey>
+impl<const MCL: usize, const MCC: usize, const MPL: usize, N, UserPublicKey>
+    PersonalPrivateInterest<MCL, MCC, MPL, N, UserPublicKey>
 {
     pub fn private_interest(&self) -> &PrivateInterest<MCL, MCC, MPL, N, UserPublicKey> {
         &self.private_interest
@@ -33,11 +28,11 @@ impl<
 }
 
 #[cfg(feature = "dev")]
-impl<'a, const MCL: usize, const MCC: usize, const MPL: usize, N: NamespaceId, S: SubspaceId>
-    Arbitrary<'a> for PersonalPrivateInterest<MCL, MCC, MPL, N, S>
+impl<'a, const MCL: usize, const MCC: usize, const MPL: usize, N, S> Arbitrary<'a>
+    for PersonalPrivateInterest<MCL, MCC, MPL, N, S>
 where
-    N: NamespaceId + Arbitrary<'a>,
-    S: SubspaceId + Arbitrary<'a>,
+    N: Arbitrary<'a>,
+    S: Arbitrary<'a>,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {

--- a/store_simple_sled/Cargo.toml
+++ b/store_simple_sled/Cargo.toml
@@ -9,14 +9,14 @@ license = "MIT OR Apache-2.0"
 workspace = true
 
 [dependencies]
+ufotofu = { version = "0.7.0" }
+ufotofu_codec = { version = "0.1.3" }
+ufotofu_codec_endian = { version = "0.1.0" }
+ufotofu_queues = { version = "0.6.0", features = ["std"] }
+wb_async_utils = { version = "0.2.0", features = ["ufotofu_utils"] }
 sled = "0.34.7"
 willow-data-model = { path = "../data-model", version = "0.2.0" }
-ufotofu_codec = { version = "0.1.0" }
-ufotofu = { version = "0.6.4" }
-ufotofu_codec_endian = { version = "0.1.0" }
 either = "1.10.0"
-wb_async_utils = { version = "0.1.3", features = ["ufotofu_utils"] }
-ufotofu_queues = { version = "0.6.0", features = ["std"] }
 
 [dev-dependencies]
 willow_25 = { path = "../willow_25", version = "0.1.0" }

--- a/store_simple_sled/Cargo.toml
+++ b/store_simple_sled/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [dependencies]
 ufotofu = { version = "0.7.0" }
 ufotofu_codec = { version = "0.1.3" }
-ufotofu_codec_endian = { version = "0.1.0" }
+ufotofu_codec_endian = { version = "0.2.0" }
 ufotofu_queues = { version = "0.6.0", features = ["std"] }
 wb_async_utils = { version = "0.2.0", features = ["ufotofu_utils"] }
 sled = "0.34.7"

--- a/transport_encryption/Cargo.toml
+++ b/transport_encryption/Cargo.toml
@@ -6,13 +6,13 @@ description = "The recommended transport encryption for use with the WGPS of Wil
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-ufotofu = { version = "0.6.0", features = ["std"] }
-ufotofu_codec = "0.1.0"
+ufotofu = { version = "0.7.0", features = ["std"] }
+ufotofu_codec = "0.1.3"
 either = "1.10.0"
 
 [dev-dependencies]
 smol = "2.0.2"
-wb_async_utils = { version = "0.1.3", features = ["ufotofu_utils"] }
+wb_async_utils = { version = "0.2.0", features = ["ufotofu_utils"] }
 ufotofu_queues = "0.6.0"
 futures = "0.3.31"
 

--- a/wgps/Cargo.toml
+++ b/wgps/Cargo.toml
@@ -12,6 +12,7 @@ ufotofu = { version = "0.7.0", features = ["std"] }
 ufotofu_codec = { version = "0.1.3" }
 wb_async_utils = { version = "0.2.0" }
 ufotofu_queues = { version = "0.6.0", features = ["std"] }
+compact_u64 = { version = "0.2.0", features = ["std", "dev"] }
 willow-data-model = { path = "../data-model", version = "0.2.0" }
 lcmux = { path = "../lcmux", version = "0.1.0" }
 futures = { version = "0.3.31" }
@@ -21,7 +22,6 @@ async_cell = "0.2.2"
 willow-transport-encryption = { path = "../transport_encryption" }
 multimap = "0.10.1"
 willow-encoding = { path = "../encoding", version = "0.1.0" }
-compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
 willow-pio = { version = "0.1.0", path = "../pio" }
 
 [dev-dependencies]

--- a/wgps/Cargo.toml
+++ b/wgps/Cargo.toml
@@ -8,21 +8,21 @@ default = []
 dev = ["dep:arbitrary"]
 
 [dependencies]
-arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-wb_async_utils = { version = "0.1.3" }
-willow-data-model = { path = "../data-model", version = "0.2.0" }
-ufotofu_codec = { version = "0.1.1" }
-ufotofu = { version = "0.6.6", features = ["std"] }
-lcmux = { path = "../lcmux", version = "0.1.0" }
+ufotofu = { version = "0.7.0", features = ["std"] }
+ufotofu_codec = { version = "0.1.3" }
+wb_async_utils = { version = "0.2.0" }
 ufotofu_queues = { version = "0.6.0", features = ["std"] }
+willow-data-model = { path = "../data-model", version = "0.2.0" }
+lcmux = { path = "../lcmux", version = "0.1.0" }
 futures = { version = "0.3.31" }
+arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
 either = "1.10.0"
 async_cell = "0.2.2"
 willow-transport-encryption = { path = "../transport_encryption" }
 multimap = "0.10.1"
 willow-encoding = { path = "../encoding", version = "0.1.0" }
-compact_u64 = { version = "0.1.0", features = [ "std", "dev" ] }
-willow-pio = {version = "0.1.0", path = "../pio" }
+compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
+willow-pio = { version = "0.1.0", path = "../pio" }
 
 [dev-dependencies]
 smol = "2.0.0"

--- a/wgps/src/pio/salted_hashes.rs
+++ b/wgps/src/pio/salted_hashes.rs
@@ -14,8 +14,8 @@ pub(crate) struct HashRegistry<
     const MCL: usize,
     const MCC: usize,
     const MPL: usize,
-    N: NamespaceId,
-    S: SubspaceId,
+    N,
+    S,
 > {
     pub(crate) my_salt: [u8; SALT_LENGTH],
     pub(crate) h:

--- a/willow_25/Cargo.toml
+++ b/willow_25/Cargo.toml
@@ -10,16 +10,16 @@ default = []
 dev = ["dep:arbitrary", "willow-data-model/dev", "meadowcap/dev"]
 
 [dependencies]
+ufotofu = { version = "0.7.0", features = ["std"] }
+ufotofu_codec = { version = "0.1.3" }
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 willow-data-model = { path = "../data-model", version = "0.2.0" }
 meadowcap = { path = "../meadowcap", version = "0.2.0" }
-ufotofu_codec = { version = "0.1.0" }
-ufotofu = { version = "0.6.0", features = ["std"] }
 rand = "0.8.5"
 signature = "2.2.0"
 blake3 = "1.8.0"
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-compact_u64 = { version = "0.1.0", features = [ "std", "dev" ] }
+compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
 willow-encoding = { path = "../encoding", version = "0.1.0" }
 
 [lints]

--- a/willow_25/Cargo.toml
+++ b/willow_25/Cargo.toml
@@ -12,6 +12,7 @@ dev = ["dep:arbitrary", "willow-data-model/dev", "meadowcap/dev"]
 [dependencies]
 ufotofu = { version = "0.7.0", features = ["std"] }
 ufotofu_codec = { version = "0.1.3" }
+compact_u64 = { version = "0.2.0", features = ["std", "dev"] }
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 willow-data-model = { path = "../data-model", version = "0.2.0" }
 meadowcap = { path = "../meadowcap", version = "0.2.0" }
@@ -19,7 +20,6 @@ rand = "0.8.5"
 signature = "2.2.0"
 blake3 = "1.8.0"
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-compact_u64 = { version = "0.1.0", features = ["std", "dev"] }
 willow-encoding = { path = "../encoding", version = "0.1.0" }
 
 [lints]

--- a/willow_test_vectors/Cargo.toml
+++ b/willow_test_vectors/Cargo.toml
@@ -4,22 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+ufotofu = "0.7.0"
+ufotofu_codec = { version = "0.1.3", features = ["std", "dev"] }
 arbitrary = "1.4.1"
 willow_25 = { path = "../willow_25", features = ["dev"] }
 willow-data-model = { path = "../data-model", version = "0.2.0", features = [
     "dev",
 ] }
 meadowcap = { path = "../meadowcap", features = ["dev"] }
-ufotofu_codec = { version = "0.1.0", features = ["std", "dev"] }
 pollster = "0.4.0"
-ufotofu = "0.6.5"
-
-[patch.crates-io]
-ufotofu_codec = { path = "../../ufotofu/ufotofu_codec", features = [
-    "std",
-    "dev",
-] }
-ufotofu = { path = "../../ufotofu/ufotofu", features = ["std", "dev"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Removes trait bounds from types, and simplifies a couple of references to opaque state objects by hardcoding them to RCs instead.